### PR TITLE
Add optional tags field to objectives and indicators

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,6 @@
 {
     "default": true,
     "MD013": {
-        "line_length": 120
+        "line_length": 140
     }
 }

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ spec:
 - **objectives\[ \]** *Threshold*, required field, described in [Objectives](#objectives)
   section
 
+- **tags\[ \]** *string*, optional, a list of tags associated with the SLO
+
 ##### Objectives
 
 Objectives are the thresholds for your SLOs. You can use objectives to define
@@ -152,7 +154,7 @@ the tolerance levels for your metrics
 ```yaml
 objectives:
   - displayName: string # optional
-    tags: # optional, list of tags associated with this SLO
+    tags: string[] # optional, array list of tags associated with this SLO
     op: lte | gte | lt | gt # conditional operator used to compare the SLI against the value. Only needed when using a thresholdMetric
     value: numeric # value used to compare metrics values. All objectives of the SLO need to have a unique value.
     target: numeric [0.0, 1.0) # budget target for given objective of the SLO
@@ -250,6 +252,8 @@ objectives:
   - *Total* represents the query used for gathering data from metric sources
     that is used as the denominator. Received data is used to compare objectives
     (threshold) values to find total number of metrics.
+
+- **tags\[ \]** *string*, optional, a list of tags associated with the objective of the SLO
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,13 @@ kind: SLO
 metadata:
   name: string
   displayName: string # optional
-  labels: # optional, key <>value a pair of labels that can be used as metadata
+  labels: # optional, key <>value a pair of labels that can be used as metadata relevant to users
     userImpacting: "true"
+    team: "identity"
+    costCentre: "project1"
+    serviceTier: "tier-1"
     tags:
       - auth
-      - tier-1
 spec:
   description: string # optional
   service: [service name] # name of the service to associate this SLO with
@@ -107,10 +109,10 @@ spec:
 ##### Notes (SLO)
 
 - **metadata.labels:** *map[string]string|string[]* - optional field `key` <> `value`
-  - the `name` segment is required and must contain at most 63 characters beginning and ending
+  - the `key` segment is required and must contain at most 63 characters beginning and ending
      with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`
      and alphanumerics between.
-  - the `value` of `name` segment can be a string or an array of strings
+  - the `value` of `key` segment can be a string or an array of strings
 - **indicator** optional, represents the Service Level Indicator (SLI).
   Currently this only supports one Metric, `thresholdMetric`, with `ratioMetric`
   supported in the [objectives](#objectives) stanza.

--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ spec:
 ##### Notes (SLO)
 
 - **metadata.labels:** *map[string]string|string[]* - optional field `key` <> `value`
-   - the `name` segment is required and must contain at most 63 characters beginning and ending
+  - the `name` segment is required and must contain at most 63 characters beginning and ending
      with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`
      and alphanumerics between.
-   - the `value` of `name` segment can be a string or an array of strings
+  - the `value` of `name` segment can be a string or an array of strings
 - **indicator** optional, represents the Service Level Indicator (SLI).
   Currently this only supports one Metric, `thresholdMetric`, with `ratioMetric`
   supported in the [objectives](#objectives) stanza.

--- a/README.md
+++ b/README.md
@@ -72,10 +72,13 @@ kind: SLO
 metadata:
   name: string
   displayName: string # optional
+  labels: # optional, key <>value a pair of labels that can be used as metadata
+    tags:
+      - auth
+      - tier-1
 spec:
   description: string # optional
   service: [service name] # name of the service to associate this SLO with
-  tags: # optional, list of tags associated with this SLO
   indicator: # represents the Service Level Indicator (SLI)
     thresholdMetric: # represents the metric used to inform the Service Level Object in the objectives stanza
       source: string # data source for the metric
@@ -102,6 +105,11 @@ spec:
 
 ##### Notes (SLO)
 
+- **metadata.labels:** *map[string]string|string[]* - optional field `key` <> `value`
+   - the `name` segment is required and must contain at most 63 characters beginning and ending
+     with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`
+     and alphanumerics between.
+   - the `value` of `name` segment can be a string or an array of strings
 - **indicator** optional, represents the Service Level Indicator (SLI).
   Currently this only supports one Metric, `thresholdMetric`, with `ratioMetric`
   supported in the [objectives](#objectives) stanza.
@@ -144,8 +152,6 @@ spec:
 - **objectives\[ \]** *Threshold*, required field, described in [Objectives](#objectives)
   section
 
-- **tags\[ \]** *string*, optional, a list of tags associated with the SLO
-
 ##### Objectives
 
 Objectives are the thresholds for your SLOs. You can use objectives to define
@@ -154,7 +160,6 @@ the tolerance levels for your metrics
 ```yaml
 objectives:
   - displayName: string # optional
-    tags: string[] # optional, array list of tags associated with this SLO
     op: lte | gte | lt | gt # conditional operator used to compare the SLI against the value. Only needed when using a thresholdMetric
     value: numeric # value used to compare metrics values. All objectives of the SLO need to have a unique value.
     target: numeric [0.0, 1.0) # budget target for given objective of the SLO
@@ -252,8 +257,6 @@ objectives:
   - *Total* represents the query used for gathering data from metric sources
     that is used as the denominator. Received data is used to compare objectives
     (threshold) values to find total number of metrics.
-
-- **tags\[ \]** *string*, optional, a list of tags associated with the objective of the SLO
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ metadata:
   name: string
   displayName: string # optional
   labels: # optional, key <>value a pair of labels that can be used as metadata
+    userImpacting: "true"
     tags:
       - auth
       - tier-1

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ metadata:
 spec:
   description: string # optional
   service: [service name] # name of the service to associate this SLO with
+  tags: # optional, list of tags associated with this SLO
   indicator: # represents the Service Level Indicator (SLI)
     thresholdMetric: # represents the metric used to inform the Service Level Object in the objectives stanza
       source: string # data source for the metric
@@ -151,6 +152,7 @@ the tolerance levels for your metrics
 ```yaml
 objectives:
   - displayName: string # optional
+    tags: # optional, list of tags associated with this SLO
     op: lte | gte | lt | gt # conditional operator used to compare the SLI against the value. Only needed when using a thresholdMetric
     value: numeric # value used to compare metrics values. All objectives of the SLO need to have a unique value.
     target: numeric [0.0, 1.0) # budget target for given objective of the SLO


### PR DESCRIPTION
Introduces the optional field `tags` to allow to associate tags with objectives or indicators. Allowing systems that leverage the OpensLO files to display tags, or allow easy filtering by tags in UI interfaces

I am not 100% sure if it makes sense to add the field to both of it, I think there was some discussion about potentially moving out the objectives into a separate file. Happy to discuss it.

An example would be:

```
apiVersion: openslo/v1alpha
kind: SLO
metadata:
  name: slo-my-service
  displayName: Requests Availability
spec:
  service: my-service
  tags: 
     - availability
     - common-slo
     - my-service
  description: "Common SLO based on availability for HTTP request responses."
  budgetingMethod: Occurrences
  objectives:
    - ratioMetrics:
        good:
          source: prometheus
          queryType: promql
          query: sum(rate(http_request_duration_seconds_count{job="myservice",code!~"(5..|429)"}[{{.window}}]))
        total:
          source: prometheus
          queryType: promql
          query: sum(rate(http_request_duration_seconds_count{job="myservice"}[{{.window}}]))
      target: 0.97
  timeWindows:
    - count: 30
       unit: Day
```