### PR TITLE
feat(alert): proposes a way to describe alerting policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,11 +340,11 @@ spec:
         name: cpu-usage-breach
         displayName: CPU Usage breaching
       spec:
-        description: Condition for CPU usage breach check with burn rate over 50% for longer then five minutes
+        description: SLO burn rate exceeds for cpu-usage-breach exceeds 2
         severity: page
         condition:
-          kind: burnate
-          threshold: 0.5
+          kind: burnrate
+          threshold: 2
           lookbackWindow: 1h
           alertAfter: 5m
   notificationTargets:
@@ -415,7 +415,7 @@ spec:
   severity: page
   condition:
     kind: burnrate
-    threshold: 0.9
+    threshold: 2
     lookbackWindow: 1h
     alertAfter: 5m
 ```

--- a/README.md
+++ b/README.md
@@ -500,6 +500,13 @@ spec:
 - **target** *string*, describes the target of the notification, e.g. Slack, email, web-hook, Opsgenie etc
 - **description** *string*, optional description about the notification target
 
+*Note*: The way the alert notification targets are is an implementation detail of the
+system that consumes the OpenSLO specification.
+
+For example, if the OpenSLO is consumed by a solution that generates Prometheus recording rules,
+and alerts, you can imagine that the name of the alert notification gets passed as label
+to Alertmanager which then can be routed accordingly based on this label.
+
 ---
 
 #### Service

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ If the alert condition is resolved, and the alert policy has `alertWhenResolved`
 the alert will be triggered
 
 If the *service level objective* associated with the alert condition returns no value for the burn rate,
-for example, due to the service level indicators missing data (e.g. no time series being returned)
+for example, due to the service level indicators missing data (e.g. no time series being returned) and the `alertWhenNoData` is set to `true` the alert will be triggered.
 
 *Note*: The `alertWhenBreaching` and `alertWhenResolved`, `alertWhenNoData` can be combined,
 if you want an alert to trigger when in all circumstances or for each separately.

--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ spec:
     - **alertAfter** *number*: required field, the duration the condition needs to be valid, defaults `0m`
   If the kind is `custom` the following fields are required:
     - **threshold** *number*, required field, the threshold that you want alert on
+    - **condition** *enum(lt, lte, gt, gte, eq)*, optional field, defines how the threshold should be met, defaults to `gt`
   If the kind is `guard` the following fields are required, can  be used to define quality conditions:
     - **threshold** *number*, required field, the threshold that you want alert on
     - **criteriaType** *enum(pass, warning)*, required field, defines the criteria type of the condition

--- a/README.md
+++ b/README.md
@@ -299,20 +299,26 @@ spec:
 - **severity** *enum(ticket, page)*, required field. The severity level of the alert
 - **condition**, required field. Defines the conditions of the alert
   - **kind** *enum(burnrate, guard, custom)* the kind of alerting condition thats checked, defaults to `burnrate`
-  If the kind is `burnrate` the following fields are required:
-  - **threshold** *number*, required field, the threshold that you want alert on
-  - **lookbackWindow** *number*, required field, the time-frame for which to calculate the threshold
-  - **controlLookbackWindow** *number*, optional field
-  - **alertAfter** *number*: required field, the duration the condition needs to be valid, defaults `0m`
-  If the kind is `custom` the following fields are required:
-  - **threshold** *number*, required field, the threshold that you want alert on
-  - **comparison** *enum(lt, lte, gt, gte, eq)*, optional field, defines
+
+If the kind is `burnrate` the following fields are required:
+
+- **threshold** *number*, required field, the threshold that you want alert on
+- **lookbackWindow** *number*, required field, the time-frame for which to calculate the threshold
+- **controlLookbackWindow** *number*, optional field
+- **alertAfter** *number*: required field, the duration the condition needs to be valid, defaults `0m`
+
+If the kind is `custom` the following fields are required:
+
+- **threshold** *number*, required field, the threshold that you want alert on
+- **comparison** *enum(lt, lte, gt, gte, eq)*, optional field, defines
   how the threshold should be compared to meet the threshold, defaults to `gt`
-  If the kind is `guard` the following fields are required, can  be used to
-  define quality conditions:
-  - **threshold** *number*, required field, the threshold that you want alert on
-  - **criteriaType** *enum(pass, warning)*, required field, defines the criteria type of the condition
-  - **weight** *number*, required field, the weight or importance of the condition
+
+If the kind is `guard` the following fields are required, can  be used to
+define quality conditions:
+
+- **threshold** *number*, required field, the threshold that you want alert on
+- **criteriaType** *enum(pass, warning)*, required field, defines the criteria type of the condition
+- **weight** *number*, required field, the weight or importance of the condition
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ spec:
         name: cpu-usage-breach
         displayName: CPU Usage breaching
       spec:
-        description: SLO burn rate exceeds for cpu-usage-breach exceeds 2
+        description: SLO burn rate for cpu-usage-breach exceeds 2
         severity: page
         condition:
           kind: burnrate

--- a/README.md
+++ b/README.md
@@ -305,17 +305,17 @@ The table below lists the outcomes of the different combinations:
 In the table below lists when alert policy will be triggering depending on
 the resolved alert condition value:
 
-| Alert condition | alertIf       | Alert triggering |
-|-----------------|---------------|------------------|
-| true            | true          | Yes              |
-| true            | false         | No               |
-| true            | indeterminate | No               |
-| false           | true          | Yes              |
-| false           | false         | No               |
-| false           | indeterminate | No               |
-| indeterminate   | true          | No               |
-| indeterminate   | false         | No               |
-| indeterminate   | indeterminate | Yes              |
+| Alert condition | alertIf | Alert triggering |
+|---|---|---|
+| true | true | Yes |
+| true | false | No |
+| true | indeterminate | No |
+| false | true | Yes |
+| false | false | No |
+| false | indeterminate | No |
+| indeterminate | true | No |
+| indeterminate | false | No |
+| indeterminate | indeterminate | Yes |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@
       - [SLO](#slo)
         - [Notes](#notes-1)
         - [Objectives](#objectives)
-      - [Alerting](#alerting)
-        - [Notes](#notes-2)
-        - [Conditions](#conditions)
-        - [Targets](#targets)
+      - [Alerting](#alert-policy)
+        - [Notes](#notes-alert-policy)
+        - [Alert Conditions](#alert-condition)
+        - [Notification Targets](#alert-notification-target)
       - [Service](#service)
 
 ## Introduction

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ spec:
     - **alertAfter** *number*: required field, the duration the condition needs to be valid, defaults `0m`
   If the kind is `custom` the following fields are required:
     - **threshold** *number*, required field, the threshold that you want alert on
-    - **condition** *enum(lt, lte, gt, gte, eq)*, optional field, defines how the threshold should be met, defaults to `gt`
+    - **comparison** *enum(lt, lte, gt, gte, eq)*, optional field, defines how the threshold should be compared to meet the threshold, defaults to `gt`
   If the kind is `guard` the following fields are required, can  be used to define quality conditions:
     - **threshold** *number*, required field, the threshold that you want alert on
     - **criteriaType** *enum(pass, warning)*, required field, defines the criteria type of the condition

--- a/README.md
+++ b/README.md
@@ -305,17 +305,17 @@ The table below lists the outcomes of the different combinations:
 In the table below lists when alert policy will be triggering depending on
 the resolved alert condition value:
 
-| Alert condition     | alertIf       | Alert triggering |
-|-------------------------------------|------------------|
-| true                | true          | Yes              |
-| true                | false         | No               |
-| true                | indeterminate | No               |
-| false               | true          | Yes              |
-| false               | false         | No               |
-| false               | indeterminate | No               |
-| indeterminate       | true          | No               |
-| indeterminate       | false         | No               |
-| indeterminate       | indeterminate | Yes              |
+| Alert condition | alertIf       | Alert triggering |
+|-----------------|---------------|------------------|
+| true            | true          | Yes              |
+| true            | false         | No               |
+| true            | indeterminate | No               |
+| false           | true          | Yes              |
+| false           | false         | No               |
+| false           | indeterminate | No               |
+| indeterminate   | true          | No               |
+| indeterminate   | false         | No               |
+| indeterminate   | indeterminate | Yes              |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ objectives:
     (threshold) values to find total number of metrics.
 
 #### Alert Policy
+
 An Alert Policy allows you to define the alert conditions for a SLO.
 
 ```yaml
@@ -237,19 +238,20 @@ spec:
   conditions: # list of alert conditions
     - conditionRef: # required when alert condition is not inlined
   notificationTargets:
-    - targetRef: # required when alert notification target is not inlined
+  - targetRef: # required when alert notification target is not inlined
 
 ```
 
 #### Notes (Alert Policy)
+
 - **conditions\[ \]** *Alert Condition*, required field.
   A condition can be inline defined or can refer to external Alert condition defined
   in this case the following are required:
-    - **conditionRef** *string*: this is the name or path the Alert condition
+  - **conditionRef** *string*: this is the name or path the Alert condition
 - **notificationTargets\[ \]** *Alert Notification Target*, required field.
   A condition can be inline defined or can refer to external Alert Notification Target
   defined in this case the following are required:
-    - **targetRef** *string*: this is the name or path the Alert Notification Target
+  - **targetRef** *string*: this is the name or path the Alert Notification Target
 
 An example of a Alert policy which refers to another Alert Condition:
 
@@ -260,9 +262,9 @@ metadata:
   name: AlertPolicy
   displayName: Alert Policy
 spec:
-  description: Alert policy for cpu utilisation breaches, notifies on-call devops via email
+  description: Alert policy for cpu usage breaches, notifies on-call devops via email
   conditions:
-    - conditionRef: cpu-utilisation-breach
+    - conditionRef: cpu-usage-breach
   notificationTargets:
     - targetRef: OnCallDevopsMailNotification
 
@@ -271,6 +273,7 @@ spec:
 ---
 
 #### Alert Condition
+
 An Alert Condition allows you to define in which conditions a alert of SLO
 needs to be triggered.
 
@@ -292,21 +295,25 @@ spec:
 ```
 
 #### Notes (Alert Condition)
+
 - **severity** *enum(ticket, page)*, required field. The severity level of the alert
 - **condition**, required field. Defines the conditions of the alert
   - **kind** *enum(burnrate, guard, custom)* the kind of alerting condition thats checked, defaults to `burnrate`
   If the kind is `burnrate` the following fields are required:
-    - **threshold** *number*, required field, the threshold that you want alert on
-    - **lookbackWindow** *number*, required field, the time-frame for which to calculate the threshold
-    - **controlLookbackWindow** *number*, optional field
-    - **alertAfter** *number*: required field, the duration the condition needs to be valid, defaults `0m`
+  - **threshold** *number*, required field, the threshold that you want alert on
+  - **lookbackWindow** *number*, required field, the time-frame for which to calculate the threshold
+  - **controlLookbackWindow** *number*, optional field
+  - **alertAfter** *number*: required field, the duration the condition needs to be valid, defaults `0m`
   If the kind is `custom` the following fields are required:
-    - **threshold** *number*, required field, the threshold that you want alert on
-    - **comparison** *enum(lt, lte, gt, gte, eq)*, optional field, defines how the threshold should be compared to meet the threshold, defaults to `gt`
-  If the kind is `guard` the following fields are required, can  be used to define quality conditions:
-    - **threshold** *number*, required field, the threshold that you want alert on
-    - **criteriaType** *enum(pass, warning)*, required field, defines the criteria type of the condition
-    - **weight** *number*, required field, the weight or importance of the condition
+  - **threshold** *number*, required field, the threshold that you want alert on
+  - **comparison** *enum(lt, lte, gt, gte, eq)*, optional field, defines
+  how the threshold should be compared to meet the threshold, defaults to `gt`
+  If the kind is `guard` the following fields are required, can  be used to
+  define quality conditions:
+  - **threshold** *number*, required field, the threshold that you want alert on
+  - **criteriaType** *enum(pass, warning)*, required field, defines the criteria type of the condition
+  - **weight** *number*, required field, the weight or importance of the condition
+
 ---
 
 An example of a alert condition is the following:
@@ -315,10 +322,10 @@ An example of a alert condition is the following:
 apiVersion: openslo/v1alpha
 kind: AlertCondition
 metadata:
-  name: cpu-utilisation-breach
-  displayName: CPU utilisation breach
+  name: cpu-usage-breach
+  displayName: CPU usage breach
 spec:
-  description: If the CPU utilisation is too high for given period then it should alert
+  description: If the CPU usage is too high for given period then it should alert
   severity: page
   condition:
     kind: burnrate
@@ -330,6 +337,7 @@ spec:
 ---
 
 #### Alert Notification Target
+
 An Alert Notification Target defines the possible targets where alert notifications
 should be delivered to. For example, this can be a web-hook, Slack or similar
 
@@ -368,7 +376,6 @@ spec:
 
 Alternatively, a similar notification target can be defined for Slack in this example
 
-
 ```yaml
 apiVersion: openslo/v1alpha
 kind: AlertNotificationTarget
@@ -392,14 +399,17 @@ spec:
         Don't forget to schedule a meeting the company board via Executive Secretary
 ```
 
-##### Notes
+##### Notes (Alert Notification Target)
+
 - **target** *string*, describes the target of the notification, e.g. Slack, email, web-hook, Opsgenie etc
 - **description** *string*, optional description about the notification target
 - **parameters**, defined all the available parameters for the target, e.g. username, password, Slack web-hook url
   - **name** *string*, unique name of the parameter
   - **description** *string* (optional), human readable description of the parameter
-  - **type** *enum(string, secret, number, email, url)* the accepted type of value of the parameter, if not given it fallbacks to `string`
-  - **value** *string*, a hard-coded value of the parameter name (e.g. web-hook url)
+  - **type** *enum(string, secret, number, email, url)* the accepted type of
+  value of the parameter, if not given it fallbacks to `string`
+  - **value** *string*, a hard-coded value of the parameter name
+    (e.g. web-hook url)
   - **defaultValue** *string*, a fallback or default value for the parameter
 
 **Note**: The OpenSLO comes with a few so called template fields which can be used as part of the specification to
@@ -417,12 +427,6 @@ kind: Service
 metadata:
   name: string
   displayName: string # optional
-  opensloApiVersion: openslo/v1alpha # required, when apiVersion is not a OpenSLO api version
 spec:
   description: string # optional up to 1050 characters
 ```
-
-##### Notes
- - The `apiVersion` can define a different api version, e.g. of a third-party service catalog,
-   if this field does not have a version that prefixes with `openslo/` then the `opensloApiVersion`-field in `metadata` is *required*
-- The `opensloApiVersion`-field is required when `apiVersion` is not populated with a valid OpenSLO api version

--- a/README.md
+++ b/README.md
@@ -325,8 +325,8 @@ If we have 1 error out of a total of 100 requests, the calculated value for
 the indicator would be: `(100 - 1 )  = 0.99`. This represents 99% on a 0-100 scale
 using the formula `0.99 * 100 = 99`.
 
-*Note*: As you can see for both query combinations we end up with the same calculated
-value for the service level indicator.
+> 💡 **Note:** : As you can see for both query combinations we end up with the same calculated
+> value for the service level indicator.
 
 #### Alert Policy
 
@@ -365,9 +365,9 @@ spec:
   defined in this case the following are required:
   - **targetRef** *string*: this is the name or path the Alert Notification Target
 
-*Note*: The `conditions`-field is of the type `array` of *AlertCondition*
-but only allows one single condition to be defined.
-The use of an array is for future-proofing purposes.
+> 💡 **Note:**: The `conditions`-field is of the type `array` of *AlertCondition*
+> but only allows one single condition to be defined.
+> The use of an array is for future-proofing purposes.
 
 An example of a Alert policy which refers to another Alert Condition:
 
@@ -463,8 +463,8 @@ no value for the burn rate, for example, due to the service level indicators
 missing data (e.g. no time series being returned) and the `alertWhenNoData`
 is set  to `true` the alert will be triggered.
 
-*Note*: The `alertWhenBreaching` and `alertWhenResolved`, `alertWhenNoData` can be combined,
-if you want an alert to trigger when in all circumstances or for each separately.
+> 💡 **Note:**: The `alertWhenBreaching` and `alertWhenResolved`, `alertWhenNoData` can be combined,
+> if you want an alert to trigger when in all circumstances or for each separately.
 
 ---
 
@@ -540,8 +540,8 @@ spec:
 - **target** *string*, describes the target of the notification, e.g. Slack, email, web-hook, Opsgenie etc
 - **description** *string*, optional description about the notification target
 
-*Note*: The way the alert notification targets are is an implementation detail of the
-system that consumes the OpenSLO specification.
+> 💡 **Note:**: The way the alert notification targets are is an implementation detail of the
+> system that consumes the OpenSLO specification.
 
 For example, if the OpenSLO is consumed by a solution that generates Prometheus recording rules,
 and alerts, you can imagine that the name of the alert notification gets passed as label

--- a/README.md
+++ b/README.md
@@ -291,15 +291,17 @@ spec:
   when the condition is resolved
 - **alertWhenNoData** *boolean*, `true`, `false`, whether the alert should be triggered
   when the condition indicates that no data is available
-- **conditions\[ \]** *Alert Condition*, an array, required field.
-  A condition can be inline defined or can refer to external Alert condition defined
-  in this case the following are required:
-  - **operator** *string*, the logical operator, can be `AND`, or `OR`, defaults to `OR`
+- **conditions\[ \]** *Alert Condition*, an array, (max of one condition), required field.
+  A condition can be defined inline or can refer to external Alert condition defined in this case the following are required:
   - **conditionRef** *string*: this is the name or path the Alert condition
 - **notificationTargets\[ \]** *Alert Notification Target*, required field.
   A condition can be inline defined or can refer to external Alert Notification Target
   defined in this case the following are required:
   - **targetRef** *string*: this is the name or path the Alert Notification Target
+
+*Note*: The `conditions`-field is of the type `array` of *AlertCondition*
+but only allows one single condition to be defined.
+The use of an array is for future-proofing purposes.
 
 An example of a Alert policy which refers to another Alert Condition:
 
@@ -316,6 +318,35 @@ spec:
   conditions:
     - operator: and
       conditionRef: cpu-usage-breach
+  notificationTargets:
+    - targetRef: OnCallDevopsMailNotification
+```
+
+An example of a Alert Policy were the Alert Condition is inlined:
+
+```yaml
+apiVersion: openslo/v1alpha
+kind: AlertPolicy
+metadata:
+  name: AlertPolicy
+  displayName: Alert Policy
+spec:
+  description: Alert policy for cpu usage breaches, notifies on-call devops via email
+  alertWhenBreaching: true
+  alertWhenResolved: false
+  conditions:
+    - kind: AlertCondition
+      metadata:
+        name: cpu-usage-breach
+        displayName: CPU Usage breaching
+      spec:
+        description: Condition for CPU usage breach check with burn rate over 50% for longer then five minutes
+        severity: page
+        condition:
+          kind: burnate
+          threshold: 0.5
+          lookbackWindow: 1h
+          alertAfter: 5m
   notificationTargets:
     - targetRef: OnCallDevopsMailNotification
 ```
@@ -361,8 +392,10 @@ the alert will be triggered
 If the alert condition is resolved, and the alert policy has `alertWhenResolved` set to `true`
 the alert will be triggered
 
-If the *service level objective* associated with the alert condition returns no value for the burn rate,
-for example, due to the service level indicators missing data (e.g. no time series being returned) and the `alertWhenNoData` is set to `true` the alert will be triggered.
+If the *service level objective* associated with the alert condition returns
+no value for the burn rate, for example, due to the service level indicators
+missing data (e.g. no time series being returned) and the `alertWhenNoData`
+is set  to `true` the alert will be triggered.
 
 *Note*: The `alertWhenBreaching` and `alertWhenResolved`, `alertWhenNoData` can be combined,
 if you want an alert to trigger when in all circumstances or for each separately.

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ metadata:
 spec:
   target: # required
   description: # optional
-  parameters: # required
+  parameters: # optional, list of parameters for the notification target
     - name: string # required
       description: string # optional
       type: string # required, string, secret, number, url
@@ -409,7 +409,7 @@ spec:
 
 - **target** *string*, describes the target of the notification, e.g. Slack, email, web-hook, Opsgenie etc
 - **description** *string*, optional description about the notification target
-- **parameters**, defined all the available parameters for the target, e.g. username, password, Slack web-hook url
+- **parameters**, optional list of the parameters for the target, e.g. username, password, Slack web-hook url
   - **name** *string*, unique name of the parameter
   - **description** *string* (optional), human readable description of the parameter
   - **type** *enum(string, secret, number, email, url)* the accepted type of

--- a/README.md
+++ b/README.md
@@ -451,23 +451,18 @@ spec:
 #### Alert Notification Target
 
 An Alert Notification Target defines the possible targets where alert notifications
-should be delivered to. For example, this can be a web-hook, Slack or similar
+should be delivered to. For example, this can be a web-hook, Slack or any other
+custom target.
 
 ```yaml
 apiVersion: openslo/v1alpha
 kind: AlertNotificationTarget
 metadata:
-  name:
+  name: string
   displayName: string # optional, human readable name
 spec:
   target: # required
   description: # optional
-  parameters: # optional, list of parameters for the notification target
-    - name: string # required
-      description: string # optional
-      type: string # required, string, secret, number, url
-      value: string # optional
-      defaultValue: string # optional
 ```
 
 An example of the Alert Notification Target can be:
@@ -480,10 +475,6 @@ metadata:
 spec:
   description: Notifies by a mail message to the on-call devops mailing group
   target: email
-  parameters:
-    - name: emailAddress
-      type: email
-      value: on-call-devops@openslo.org
 ```
 
 Alternatively, a similar notification target can be defined for Slack in this example
@@ -494,38 +485,20 @@ kind: AlertNotificationTarget
 metadata:
   name: OnCallDevopsSlackNotification
 spec:
-  description: "Sends P1 alert notifications to the #alerts channel"
+  description: "Sends P1 alert notifications to the slack channel"
   target: slack
-  parameters:
-    - name: channel
-      type: string
-      value: alerts
-    - name: webhook
-      type: url
-      value: https://hooks.slack.com/services/XXX1XXXXX/XXXXXXX8X/acdifghf7Klxy8xZCEDXyOk5I
-    - name: template
-      type: string
-      value: |-
-        A priority one alert has been triggered for the service $service_name for SLO $slo_name,
-        please extinguish the fire, thank you!
-        Don't forget to schedule a meeting the company board via Executive Secretary
 ```
 
 ##### Notes (Alert Notification Target)
 
+- **name** *string*, required, the name of the notification target
+- **metadata.labels:** *map[string]string|string[]* - optional field `key` <> `value`
+  - the `key` segment is required and must contain at most 63 characters beginning and ending
+     with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`
+     and alphanumerics between.
+  - the `value` of `key` segment can be a string or an array of strings
 - **target** *string*, describes the target of the notification, e.g. Slack, email, web-hook, Opsgenie etc
 - **description** *string*, optional description about the notification target
-- **parameters**, optional list of the parameters for the target, e.g. username, password, Slack web-hook url
-  - **name** *string*, unique name of the parameter
-  - **description** *string* (optional), human readable description of the parameter
-  - **type** *enum(string, secret, number, email, url)* the accepted type of
-  value of the parameter, if not given it fallbacks to `string`
-  - **value** *string*, a hard-coded value of the parameter name
-    (e.g. web-hook url)
-  - **defaultValue** *string*, a fallback or default value for the parameter
-
-**Note**: The OpenSLO comes with a few so called template fields which can be used as part of the specification to
-get the name of the relevant service, SLO name, SLO description and
 
 ---
 


### PR DESCRIPTION
Adds a proposal for how alerting can be added to the OpenSLO specification, fixes #37

The concept I came up with is the following after do a bunch of research of existing solutions and best practices I could fine:

- An reusable alert policy can be defined which consist of one or more alert conditions 
- An alert condition always describe conditions for alerting for the SLO the alert policy is associated with
- A alert policy can one or more alert notification targets, which describes the target were the alert needs to be send to after triggering, e.g. an email, a slack channel or opsgenie.

The idea of alert conditions is that you can different kinds but the main condition type is the `burn rate`, and type can `custom` which takes a threshold to alert on. 

As last you could use this to define so called _guard_ which can be used to define guard that need to be met e.g. allowing to block future deployments. I can imagine the target of such condition could be GitLab CI target which calls webhook or some script enables a freeze period: https://docs.gitlab.com/ee/api/freeze_periods.html
