### PR TITLE
bug: make value optional for ratioMetric

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ the tolerance levels for your metrics
 objectives:
   - displayName: string # optional
     op: lte | gte | lt | gt # conditional operator used to compare the SLI against the value. Only needed when using a thresholdMetric
-    value: numeric # optional, value used to compare metrics values. All objectives of the SLO need to have a unique value. Only needed when using a thresholdMetric
+    value: numeric # optional, value used to compare threshold metrics. Only needed when using a thresholdMetric
     target: numeric [0.0, 1.0) # budget target for given objective of the SLO
     timeSliceTarget: numeric (0.0, 1.0] # required only when budgetingMethod is set to TimeSlices
     # ratioMetric {good, total} should be defined only if thresholdMetric is not set.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ the tolerance levels for your metrics
 objectives:
   - displayName: string # optional
     op: lte | gte | lt | gt # conditional operator used to compare the SLI against the value. Only needed when using a thresholdMetric
-    value: numeric # value used to compare metrics values. All objectives of the SLO need to have a unique value.
+    value: numeric # optional, value used to compare metrics values. All objectives of the SLO need to have a unique value. Only needed when using a thresholdMetric
     target: numeric [0.0, 1.0) # budget target for given objective of the SLO
     timeSliceTarget: numeric (0.0, 1.0] # required only when budgetingMethod is set to TimeSlices
     # ratioMetric {good, total} should be defined only if thresholdMetric is not set.
@@ -176,7 +176,6 @@ Example:
 ```yaml
 objectives:
   - displayName: Foo Total Errors
-    value:  1
     target: 0.98
     ratioMetrics:
         incremental: true
@@ -201,7 +200,6 @@ The internal tool can then generate the final OpensLO specification based on the
 ```yaml
 objectives:
   - displayName: Foo Latency
-    value:  1
     target: 0.98
     ratioMetrics:
         incremental: true
@@ -230,7 +228,7 @@ objectives:
   the value. Only needed when using `thresholdMetric`
 
 - **value numeric**, required field, used to compare values gathered from
-  metric source
+  metric source. Only needed when using a `thresholdMetric`.
 
 - **target numeric** *\[0.0, 1.0)*, required, budget target for given objective
   of the SLO


### PR DESCRIPTION
Make `value` optional field as is not needed for `radioMetric`, is it needed for `thresholdMetric` though? 🤔 
Closes #8 