### PR TITLE
Feature | Add support for annotations

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,6 @@
 {
     "default": true,
     "MD013": {
-        "line_length": 120
+        "line_length": 140
     }
 }

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ kind: SLO
 metadata:
   name: string
   displayName: string # optional
-  annotations: map[string]string # optional, key <> value a pair of annotations that can be used as metadata
+  annotations: map[string]string # optional, key <> value a pair of annotations that can be used as implementation metadata
     openslo.com/key1: value1
-    openslo.com/key2: value2
+    fooimplementation.com/key2: value2
 spec:
   description: string # optional
   service: [service name] # name of the service to associate this SLO with
@@ -112,6 +112,8 @@ spec:
 ##### Notes (SLO)
 
 - **metadata.annotations:** *map[string]string* - optional field `key` <> `value`
+  - `annotations` should be used to define implementation / system specific metadata about the SLO.
+    For example, it can be metadata about a dashboard url, or how to name a metric created by the SLI, etc.
   - `key` have two segments: an optional `prefix` and `name`, separated by a slash `/`
   - the `name` segment is required and must contain at most 63 characters beginning and ending
     with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ kind: SLO
 metadata:
   name: string
   displayName: string # optional
+  annotations: map[string]string # optional, key <> value a pair of annotations that can be used as metadata
+    openslo.com/key1: value1
+    openslo.com/key2: value2
 spec:
   description: string # optional
   service: [service name] # name of the service to associate this SLO with
@@ -108,6 +111,14 @@ spec:
 
 ##### Notes (SLO)
 
+- **metadata.annotations:** *map[string]string* - optional field `key` <> `value`
+  - `key` have two segments: an optional `prefix` and `name`, separated by a slash `/`
+  - the `name` segment is required and must contain at most 63 characters beginning and ending
+    with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`
+    and alphanumerics between.
+  - the `prefix` is optional and must be a DNS subdomain: a series of DNS labels separated by dots `.`,
+    it must contain at most 253 characters, followed by a slash `/`.
+  - the `openslo.com/` is reserved for OpenSLO usage
 - **indicator** optional, represents the Service Level Indicator (SLI).
   Currently this only supports one Metric, `thresholdMetric`, with `ratioMetric`
   supported in the [objectives](#objectives) stanza.


### PR DESCRIPTION
Add support for annotations, I used [K8s spec](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set) to avoid reinventing the wheel 😆 

Closes #57  