### PR TITLE
Expand | add field for specifying timeslice window size in objectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ objectives:
     value: numeric # optional, value used to compare threshold metrics. Only needed when using a thresholdMetric
     target: numeric [0.0, 1.0) # budget target for given objective of the SLO
     timeSliceTarget: numeric (0.0, 1.0] # required only when budgetingMethod is set to TimeSlices
+    timeSliceWindow: number | duration-shorthand # required only when budgetingMethod is set to TimeSlices
     # ratioMetric {good, total} or {bad, total} should be defined only if thresholdMetric is not set.
     # ratioMetric good or bad and total have to contain the same source type configuration (for example for prometheus).
     ratioMetric:
@@ -277,8 +278,13 @@ objectives:
 - **target numeric** *[0.0, 1.0)*, required, budget target for given objective
   of the SLO
 
-- **targetTimeSlices** *numeric* *[0.0, 1.0]*, required only when budgeting
+- **timeSliceTarget** *numeric* *[0.0, 1.0]*, required only when budgeting
   method is set to TimeSlices
+
+- **timeSliceWindow** *(numeric | duration-shorthand)*, required only when budgeting
+  method is set to TimeSlices. Denotes the size of timeslice for which data will be
+  evaluated e.g. 5, 1m, 10m, 2h, 1d. Also ascertains the frequency at which to run the
+  queries. Default interpretation of unit if specified as a number is minutes.
 
 - **indicator.ratioMetric** *Metric {Good, Total} or {Bad, Total}*
   if `ratioMetric` is defined then `thresholdMetric` should not be set in `indicator`


### PR DESCRIPTION
a way to specify the size of timeslice window (e.g. to have control over p95 latency for requests in 1 minute vs 10 minute window) .

- also resolves https://github.com/OpenSLO/OpenSLO/issues/55 & https://openslo.slack.com/archives/C0202J83M3R/p1637202808100200
- also fixes small typo in description for `timeSliceTarget` 