### PR TITLE
Change AlertCondition.severity to optional, allow any string

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,8 +431,8 @@ metadata:
   name: string
   displayName: string # optional
 spec:
-  description: # optional
-  severity: string # optional 
+  description: string # optional
+  severity: string # optional
   condition: # optional
     kind: string
     threshold: number

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ metadata:
   displayName: string # optional
 spec:
   description: string # optional
-  severity: string # optional
+  severity: string # required
   condition: # optional
     kind: string
     threshold: number
@@ -442,7 +442,7 @@ spec:
 
 #### Notes (Alert Condition)
 
-- **severity** *string* , optional field. The severity level of the alert
+- **severity** *string* , required field describing the severity level of the alert (ex. "sev1", "page", etc.)
 - **condition**, required field. Defines the conditions of the alert
   - **kind** *enum(burnrate)* the kind of alerting condition thats checked, defaults to `burnrate`
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ metadata:
   displayName: string # optional
 spec:
   description: # optional
-  severity: string # required (ticket or page)
+  severity: string # optional 
   condition: # optional
     kind: string
     threshold: number
@@ -442,7 +442,7 @@ spec:
 
 #### Notes (Alert Condition)
 
-- **severity** *enum(ticket, page)*, required field. The severity level of the alert
+- **severity** *string* , optional field. The severity level of the alert
 - **condition**, required field. Defines the conditions of the alert
   - **kind** *enum(burnrate)* the kind of alerting condition thats checked, defaults to `burnrate`
 


### PR DESCRIPTION
## Summary 
- Updates `AlertCondition.severity` to be an optional field, and allow any string value

### Description
The concept of `severity` is likely to be varied across both AlertConditions and NotificationTargets.  The current implementation seems to act as a hint to the NotificationTarget about what type of notification should be sent (ticket or page), but it's likely that teams and services will have their own custom definitions of what `severity` means for a given alert breach or incident. 

For example, a team might using a numeric scaling of incident severity (Sev0, Sev1, Sev2) etc. with each severity level determining the course of notification action (Sev0 - page immediately and escalate in 5 min if unacked, Sev1 - page immediately and repeat every 30min unacked, etc.)

By decoupling the logic between AlertCondition severity and the type of Notification sent, the spec can be flexible enough to adapt to a wider variety of implementations and expectations. 

Other potential considerations would be moving the `severity` field to `AlertCondition.metadata` or potentially even `AlertCondition.metadata.labels` 