### PR TITLE
SLI as a Separate Kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,6 @@ metadata:
   displayName: Foo SLO
 spec:
   indicator:
-    kind: SLI
     metadata:
       name: foo-error
       displayName: Foo Error


### PR DESCRIPTION
This PR is an attempt aiming to implement what has been discussed in issue #29 & #39.
The implementation replaces `objectives[].ratioMetrics` & `thresholdMetric` with a new separate SLI kind, under which `ratioMetric` and `thresholdMetric` are moved under beneath. 