### PR TITLE
Use always the newest Node in CI

### DIFF
--- a/.github/workflows/spell-and-markdown-checks.yml
+++ b/.github/workflows/spell-and-markdown-checks.yml
@@ -10,8 +10,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up prerequisites - node and yarn
         uses: actions/setup-node@v3
-        with:
-          node-version: "15.x"
       - name: Set up yarn cache
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"


### PR DESCRIPTION
[Updating the spelling check fails](https://github.com/OpenSLO/OpenSLO/runs/5989926072?check_suite_focus=true), because it requires a newer Node than specified in the CI config. Let's use always the latest one, we don't need to pin to a specific version for those simple checks, so we won't need to update it in the future