### PR TITLE
Allow labels and annotations on all objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ kind: DataSource | SLO | SLI | AlertPolicy | AlertCondition | AlertNotificationT
 metadata:
   name: string
   displayName: string # optional
+  labels: # optional, key <>value a pair of labels that can be used as metadata relevant to users
+    # Example labels
+    userImpacting: "true"
+    team: "identity"
+    costCentre: "project1"
+    serviceTier: "tier-1"
+    tags:
+      - auth
+  annotations: map[string]string # optional, key <> value a pair of annotations that can be used as implementation metadata
+    # Example annotations
+    openslo.com/key1: value1
+    fooimplementation.com/key2: value2
 spec:
 ```
 
@@ -76,6 +88,21 @@ spec:
   - implementations are additionally encouraged to support names that:
     - are up to 255 characters in length
     - contain lowercase alphanumeric characters or `-`, `.`, `|`, `/`, `\`
+- **metadata.labels:** *map[string]string|string[]* - optional field `key` <> `value`
+  - the `key` segment is required and must contain at most 63 characters beginning and ending
+     with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`
+     and alphanumerics between.
+  - the `value` of `key` segment can be a string or an array of strings
+- **metadata.annotations:** *map[string]string* - optional field `key` <> `value`
+  - `annotations` should be used to define implementation / system specific metadata about the SLO.
+    For example, it can be metadata about a dashboard url, or how to name a metric created by the SLI, etc.
+  - `key` have two segments: an optional `prefix` and `name`, separated by a slash `/`
+  - the `name` segment is required and must contain at most 63 characters beginning and ending
+    with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`
+    and alphanumerics between.
+  - the `prefix` is optional and must be a DNS subdomain: a series of DNS labels separated by dots `.`,
+    it must contain at most 253 characters, followed by a slash `/`.
+  - the `openslo.com/` is reserved for OpenSLO usage
 
 ### Custom Data Types
 
@@ -163,16 +190,6 @@ kind: SLO
 metadata:
   name: string
   displayName: string # optional
-  labels: # optional, key <>value a pair of labels that can be used as metadata relevant to users
-    userImpacting: "true"
-    team: "identity"
-    costCentre: "project1"
-    serviceTier: "tier-1"
-    tags:
-      - auth
-  annotations: map[string]string # optional, key <> value a pair of annotations that can be used as implementation metadata
-    openslo.com/key1: value1
-    fooimplementation.com/key2: value2
 spec:
   description: string # optional
   service: [service name] # name of the service to associate this SLO with
@@ -197,21 +214,6 @@ spec:
 
 ##### Notes (SLO)
 
-- **metadata.labels:** *map[string]string|string[]* - optional field `key` <> `value`
-  - the `key` segment is required and must contain at most 63 characters beginning and ending
-     with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`
-     and alphanumerics between.
-  - the `value` of `key` segment can be a string or an array of strings
-- **metadata.annotations:** *map[string]string* - optional field `key` <> `value`
-  - `annotations` should be used to define implementation / system specific metadata about the SLO.
-    For example, it can be metadata about a dashboard url, or how to name a metric created by the SLI, etc.
-  - `key` have two segments: an optional `prefix` and `name`, separated by a slash `/`
-  - the `name` segment is required and must contain at most 63 characters beginning and ending
-    with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`
-    and alphanumerics between.
-  - the `prefix` is optional and must be a DNS subdomain: a series of DNS labels separated by dots `.`,
-    it must contain at most 253 characters, followed by a slash `/`.
-  - the `openslo.com/` is reserved for OpenSLO usage
 - **indicator** optional, represents the Service Level Indicator (SLI),
   described in [SLI](#sli) section.
   One of `indicator` or `indicatorRef` must be given.
@@ -670,11 +672,6 @@ spec:
 
 ##### Notes (AlertNotificationTarget)
 
-- **metadata.labels:** *map[string]string|string[]* - optional field `key` <> `value`
-  - the `key` segment is required and must contain at most 63 characters beginning and ending
-     with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`
-     and alphanumerics between.
-  - the `value` of `key` segment can be a string or an array of strings
 - **target** *string*, describes the target of the notification, e.g. Slack, email, web-hook, Opsgenie etc
 - **description** *string*, optional description about the notification target
 


### PR DESCRIPTION
Currently `SLO` can use labels and annotations, `AlertNotificationTarget` can use labels and other object can't use any of them. This PR changes that and gives any object type the option to use both labels and annotations.