### PR TITLE
Require condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ metadata:
 spec:
   description: string # optional
   severity: string # required
-  condition: # optional
+  condition: # required
     kind: string
     threshold: number
     lookbackWindow: duration-shorthand


### PR DESCRIPTION
Small inconsistency, and making explicit that the `condition` is a required field