### PR TITLE
Removes unneeded operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,8 +528,7 @@ spec:
   alertWhenBreaching: true
   alertWhenResolved: false
   conditions:
-    - operator: and
-      conditionRef: cpu-usage-breach
+    - conditionRef: cpu-usage-breach
   notificationTargets:
     - targetRef: OnCallDevopsMailNotification
 ```


### PR DESCRIPTION
There was an `operator` in one of the `AlertPolicy` examples, so just removed it.  @weyert i think that you worked on this, so just a heads up on it.