### PR TITLE
Update info how to join OpenSLO Slack

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ We encourage and welcome any and all feedback from the community.
 
 ## Slack
 
-Email ian@nobl9.com to get an invite to our slack channel
+Use the button `Join our Slack` from the official website [openslo.com](https://openslo.com/).
 
 ## Making a pull request
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ specification is not controlled by a single company or individual or by a group
 with discriminatory membership criteria.  Additionally, this specification is
 designed to be extended where needed to meet the needs of the implementation.
 
+Before making a contribute please read our [contribution guideline](https://github.com/OpenSLO/OpenSLO/blob/main/CONTRIBUTING.md).
+
 ## Specification
 
 ### Goals


### PR DESCRIPTION
Update instruction about joining OpenSLO Slack since https://github.com/OpenSLO/openslo.github.io/pull/8 has been already done