### PR TITLE
Correct naming of ratioMetric from rationMetric

### DIFF
--- a/schemas/v1/parts/sli-spec.schema.json
+++ b/schemas/v1/parts/sli-spec.schema.json
@@ -19,7 +19,7 @@
 						}
 					}
 				},
-				"rationMetric": {
+				"ratioMetric": {
 					"type": "object",
 					"required": [
 						"counter",


### PR DESCRIPTION
Correct naming of `ratioMetric` from `rationMetric` for SLI specification