### PR TITLE
Add example "Treat low traffic as equally important"

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,3 +22,6 @@ Links to other resources like literature are highly appreciated.
 
 - [Budgeting method](budgeting-method/README.md) - compares Occurrences, Timeslices and RatioTimeslices
     in terms of burned budget for hypothetical situation
+
+- [Treat low traffic equally important](treat-low-traffic-as-equally-important/README.md) -
+    some systems have to maintain high reliability no matter if a handful or hundreds of people actively use its

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,4 +24,4 @@ Links to other resources like literature are highly appreciated.
     in terms of burned budget for hypothetical situation
 
 - [Treat low traffic equally important](treat-low-traffic-as-equally-important/README.md) -
-    some systems have to maintain high reliability no matter if a handful or hundreds of people actively use its
+    some systems have to maintain high reliability no matter if a handful or hundreds of people actively use it.

--- a/examples/treat-low-traffic-as-equally-important/README.md
+++ b/examples/treat-low-traffic-as-equally-important/README.md
@@ -1,9 +1,10 @@
-# Threat low traffic as equally important
+# Treat low traffic as equally important
 
 Let's imagine application that performance degration even during low traffic periods (a handful of users are not satisfied)
 should count equally with degration during peak hours when hundreds of users are not satisfied with application.
-For instance, a system for reporting incidents or calling for help should operate in such a way. One person than can't get
-is important too.
+For instance, a system for reporting incidents or calling for help should operate in such a way. One person than can't be
+served is important too. But in case of burst in requests probably something bigger is happening and system is not able to
+serve everybody with such quality.
 
 ## Which OpenSLO budgeting method should be used?
 
@@ -24,6 +25,6 @@ Assumptions:
 Number of minutes in the Timewindow: `1 week = 7 days`, `7 days = 168 hours`, `168 hours = 10 080 minutes`
 Error Budget (how many minutes can be considered as bad): `(100% - 99.95%) * 10 080 minutes = 5 minutes 2.4 seconds`
 
-Minute will be marked as bad, when just only `5` request fails and total number of requests is less than `100` in that minute, so it's very strict.
-Having over five incidents like that during one Timewindow will violate SLO and should trigger meaningful conversation in organization about
-reliability of the product.
+Timeslice allowance is `95%` and Timeslice equals `1 minute`. Thus minute (time period of Timeslice) will be marked as bad in SLO, when just
+only `5` request fails and total number of requests is less than `100` in that minute. It's very strict. Having over five incidents like
+that during one Timewindow will violate SLO and should trigger meaningful conversation in organization about reliability of the product.

--- a/examples/treat-low-traffic-as-equally-important/README.md
+++ b/examples/treat-low-traffic-as-equally-important/README.md
@@ -1,0 +1,29 @@
+# Threat low traffic as equally important
+
+Let's imagine application that performance degration even during low traffic periods (a handful of users are not satisfied)
+should count equally with degration during peak hours when hundreds of users are not satisfied with application.
+For instance, a system for reporting incidents or calling for help should operate in such a way. One person than can't get
+is important too.
+
+## Which OpenSLO budgeting method should be used?
+
+Timeslices fits perfectly. In this method what we measure is how many good minutes (minutes where the system is operating
+within defined boundaries) were observed, compared to the total number of minutes in the window. With this approach, a bad
+minute that occurs during a low-traffic period will have the same effect on your SLO as a bad minute caused by the fact that
+the platform is overloaded with traffic.
+
+## Concrete example
+
+Assumptions:
+
+- Timewindow: 1 week calendar (of course rolling can be used too)
+- Objective is: 99.95% of successful requests.
+- Timeslice allowance (target) is 95%.
+- Timeslice is 1 minute.
+
+Number of minutes in the Timewindow: `1 week = 7 days`, `7 days = 168 hours`, `168 hours = 10 080 minutes`
+Error Budget (how many minutes can be considered as bad): `(100% - 99.95%) * 10 080 minutes = 5 minutes 2.4 seconds`
+
+Minute will be marked as bad, when just only `5` request fails and total number of requests is less than `100` in that minute, so it's very strict.
+Having over five incidents like that during one Timewindow will violate SLO and should trigger meaningful conversation in organization about
+reliability of the product.

--- a/examples/treat-low-traffic-as-equally-important/README.md
+++ b/examples/treat-low-traffic-as-equally-important/README.md
@@ -1,10 +1,10 @@
 # Treat low traffic as equally important
 
-Let's imagine application that performance degration even during low traffic periods (a handful of users are not satisfied)
-should count equally with degration during peak hours when hundreds of users are not satisfied with application.
+Let's imagine an application that performance degradation even during low traffic periods (a handful of users are not satisfied)
+should count equally with degradation during peak hours when hundreds of users are not satisfied with the application.
 For instance, a system for reporting incidents or calling for help should operate in such a way. One person than can't be
-served is important too. But in case of burst in requests probably something bigger is happening and system is not able to
-serve everybody with such quality.
+served is important too. But in case of bursts in requests probably something bigger is happening and the system is not able to
+serve everybody with such quality (probably it should be tracked too with a separate SLO).
 
 ## Which OpenSLO budgeting method should be used?
 

--- a/examples/treat-low-traffic-as-equally-important/timeslices-slo.yaml
+++ b/examples/treat-low-traffic-as-equally-important/timeslices-slo.yaml
@@ -1,0 +1,36 @@
+apiVersion: openslo/v1
+kind: SLO
+metadata:
+  name: service-availability
+  displayName: SLO for this important service
+spec:
+  service: web-availability
+  indicator:
+    metadata:
+      name: web-availability
+      displayName: Time when our service was running.
+    spec:
+      ratioMetric:
+        good:
+          metricSource:
+            type: Any # Any service with needed metrics
+            spec:
+              # Fields needed to query service for needed metrics
+        total:
+          metricSource:
+            type: Any # Any service with needed metrics
+            spec:
+              # Fields needed to query service for needed metrics
+  timeWindow:
+    - duration: 1w
+      isRolling: false
+      calendar:
+        startTime: 2022-01-01 12:00:00
+        timeZone: America/New_York
+  budgetingMethod: Timeslices
+  objective:
+    - displayName: Objective
+      op: gt
+      target: 0.9995
+      timeSliceTarget: 0.95
+      timeSliceWindow: 1m


### PR DESCRIPTION
A new example that describes how to set SLO for a service that malfunction during low-traffic periods is equally painful as malfunction during peak hours so a burned budget should reflect that.

Part of #174

