### PR TITLE
allow for the inclusion of arbitrary key / value metadata

### DIFF
--- a/enhancements/v2alpha1.md
+++ b/enhancements/v2alpha1.md
@@ -12,6 +12,7 @@ kind: DataSource
 metadata:
   name: string
   displayName: string # optional
+  labels: object # optional
 spec:
   description: string # optional up to 1050 characters
   <<dataSourceName>>: # e.g. cloudWatch, datadog, prometheus (arbitrary chosen, implementor decision)
@@ -44,6 +45,7 @@ kind: SLO
 metadata:
   name: string
   displayName: string # optional
+  labels: object # optional
 spec:
   description: string # optional up to 1050 characters
   service: string # name of the service to associate this SLO with, may refer (depends on implementation) to existing object Kind: Service
@@ -76,6 +78,7 @@ kind: SLI
 metadata:
   name: string
   displayName: string # optional
+  labels: object # optional
 spec:
   description: string # optional up to 1050 characters
   thresholdMetric: # either thresholdMetric or ratioMetric must be provided


### PR DESCRIPTION
When working with lots of SLO / SLI objects at scale, it can be helpful to be able to add arbitrary metadata to indicate things like:
- ownership
- association to certain projects
- criticality or other ways that teams might need to organize their SLOs, SLIs, and Datasources.

Allowing for key value pairs in the spec directly avoids having to do workarounds like depend on naming schemes.
