### PR TITLE
add optional k/v labels to Objectives

### DIFF
--- a/enhancements/v2alpha1.md
+++ b/enhancements/v2alpha1.md
@@ -73,7 +73,7 @@ spec:
   alertPolicies: # see alert policies below for details
 ```
 
-##### Objectives
+### Objectives
 
 Objectives are the thresholds for your SLOs. You can use objectives to define
 the tolerance levels for your metrics.

--- a/enhancements/v2alpha1.md
+++ b/enhancements/v2alpha1.md
@@ -66,6 +66,26 @@ spec:
   alertPolicies: # see alert policies below for details
 ```
 
+##### Objectives
+
+Objectives are the thresholds for your SLOs. You can use objectives to define
+the tolerance levels for your metrics.
+
+```yaml
+objectives:
+  - displayName: string # optional
+    labels: object # optional
+    op: lte | gte | lt | gt # conditional operator used to compare the SLI against the value. Only needed when using a thresholdMetric
+    value: numeric # optional, value used to compare threshold metrics. Only needed when using a thresholdMetric
+    target: numeric [0.0, 1.0) # budget target for given objective of the SLO, can't be used with targetPercent
+    targetPercent: numeric [0.0, 100) # budget target for given objective of the SLO, can't be used with target
+    timeSliceTarget: numeric (0.0, 1.0] # required only when budgetingMethod is set to TimeSlices
+    timeSliceWindow: number | duration-shorthand # required only when budgetingMethod is set to TimeSlices or RatioTimeslices
+    indicator: # required only when creating composite SLO, see SLI below for more details
+    indicatorRef: string # required only when creating composite SLO, required if indicator is not given.
+    compositeWeight: numeric (0.0, inf+] # optional, supported only when declaring multiple objectives, default value 1.
+```
+
 ## [SLI](../README.md#sli)
 
 **Rationale:** Get rid of `metricSource` (reduce the level of indentation), and use the new syntax of `DataSource` directly.


### PR DESCRIPTION
objectives section copied verbatim from existing spec https://github.com/OpenSLO/OpenSLO/blob/b54f77a7637f3822a12b19624c5899a038958f4f/README.md?plain=1#L263C1-L280C4, except for the addition of the labels object.

The driving use case is being able to categorize the objectives and associate them to processes or tools outside of the SLO itself. E.g. if there's a goal to improve an SLO Objective, it may want to be tagged with identifiers around that larger goal, but the existing objective may want to remain in place for existing alerting, etc.