### PR TITLE
chore: Remove contrib folder

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,1 +1,0 @@
-# External contributions to OpenSLO


### PR DESCRIPTION
We already have CONTRIBUTING.md, there seems to be no reason to keep this folder, besides, the README.md is not even finished.