### PR TITLE
fix: Change indicator to sli for v2alpha1 objectives

### DIFF
--- a/enhancements/v2alpha1.md
+++ b/enhancements/v2alpha1.md
@@ -45,7 +45,7 @@ spec:
 ## [SLO](../README.md#slo)
 
 **Rationale:** Make names more straightforward and aligned with others. Change field indicator to `sli` and `indicatorRef` to `sliRef`
-it tells which kind of object should be referred there.
+it tells which kind of object should be referred there. This change should also apply to each objective.
 
 ```yaml
 apiVersion: openslo.com/v2alpha1
@@ -90,8 +90,8 @@ objectives:
     targetPercent: numeric [0.0, 100) # budget target for given objective of the SLO, can't be used with target
     timeSliceTarget: numeric (0.0, 1.0] # required only when budgetingMethod is set to TimeSlices
     timeSliceWindow: number | duration-shorthand # required only when budgetingMethod is set to TimeSlices or RatioTimeslices
-    indicator: # required only when creating composite SLO, see SLI below for more details
-    indicatorRef: string # required only when creating composite SLO, required if indicator is not given.
+    sli: # required only when creating composite SLO, see SLI below for more details
+    sliRef: string # required only when creating composite SLO, required if sli is not given.
     compositeWeight: numeric (0.0, inf+] # optional, supported only when declaring multiple objectives, default value 1.
 ```
 
@@ -173,7 +173,7 @@ metadata:
   name: foo-slo
 spec:
   service: foo
-  indicator:
+  sli:
     metadata:
       name: foo-error
     spec:


### PR DESCRIPTION
Since the change from `indicator` to `sli` applies to the SLO spec level, it should also apply to each objective.