### PR TITLE
Proposal: Remove limits on number of objectives for Threshold SLIs

### DIFF
--- a/enhancements/v2alpha1.md
+++ b/enhancements/v2alpha1.md
@@ -80,6 +80,8 @@ spec:
 Objectives are the thresholds for your SLOs. You can use objectives to define
 the tolerance levels for your metrics.
 
+**Note:** While in the previous version only one objective was allowed for Threshold metrics, with `v2alpha1` we'll allow any number of objectives.
+
 ```yaml
 objectives:
   - displayName: string # optional


### PR DESCRIPTION
I asked in the Slack channel about where multiple objectives should apply for ratio metrics, as I wasn't sure how it could apply to Ratio but not to Threshold. Someone mentioned that they have an Objective for their internal SLO and another for the external SLA.

However, this should surely apply to Threshold metrics too, or even allow something like the following:

SLI: Kafka Topic lag  
Error Budget Method: Timeslice

- Objective 1: 95% of the time, lag should be less than 5 minutes  
- Objective 2: 99% of the time, lag should be less than 10 minutes  


This should be done with the following objectives:

```yaml
objective:
    - displayName: Lag less than 5 minutes 95% of the time
      op: lt
      value: 300
      target: 0.95
    - displayName: Lag less than 10 minutes 99% of the time
      op: lt
      value: 600
      target: 0.99
```

---

Note: As this is not a schema change, I believe we can just remove the comment and allow this for the current spec (rather than delaying it for v2alpha).
