### PR TITLE
fix: connection details for data source encoding

### DIFF
--- a/pkg/openslo/raw_message.go
+++ b/pkg/openslo/raw_message.go
@@ -1,0 +1,91 @@
+package openslo
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"gopkg.in/yaml.v3"
+)
+
+// NewRawMessage creates a new [RawMessage] and sets a value the message will hold.
+// When any of the marshalling methods are called, the value provided value will be encoded.
+func NewRawMessage(v any) RawMessage {
+	return RawMessage{value: v}
+}
+
+// RawMessage holds either JSON or YAML raw value.
+// It delays the decoding of the data and allows OpenSLO users to freely decode it
+// into whatever value they see fit.
+// It functions in a similar way to [json.RawMessage].
+type RawMessage struct {
+	json  []byte
+	yaml  *yaml.Node
+	value any
+}
+
+// Unmarshal is a convenience method for decoding the raw message into a value.
+// It should be used over [RawMessage.UnmarshalYAML] or [RawMessage.UnmarshalJSON],
+// which both require the user to know the original encoding of the data.
+// If [RawMessage] was constructed with [NewRawMessage], unmarshal will set
+// the provided pointer to the value passed to [NewRawMessage] constructor.
+func (m RawMessage) Unmarshal(v any) error {
+	if m.value != nil {
+		rv := reflect.ValueOf(v)
+		if rv.Kind() != reflect.Ptr || rv.IsNil() {
+			return fmt.Errorf("%T: Unmarshal on nil pointer", m)
+		}
+		rv.Elem().Set(reflect.ValueOf(m.value))
+		return nil
+	}
+	switch {
+	case len(m.json) > 0:
+		return json.Unmarshal(m.json, v)
+	case m.yaml != nil:
+		return m.yaml.Decode(v)
+	}
+	return fmt.Errorf("%T: raw message stores no data to unmarshal", m)
+}
+
+// MarshalYAML implements the [yaml.Marshaler] interface.
+func (m RawMessage) MarshalYAML() (any, error) {
+	if m.value != nil {
+		return m.value, nil
+	}
+	return m.yaml, nil
+}
+
+// UnmarshalYAML implements the [yaml.Marshaler] interface.
+func (m *RawMessage) UnmarshalYAML(node *yaml.Node) error {
+	if m.json != nil {
+		return fmt.Errorf("%T: ambigous state, data was already unmarshalled using JSON encoding", m)
+	}
+	if m == nil {
+		return fmt.Errorf("%T: UnmarshalYAML on nil pointer", m)
+	}
+	m.yaml = node
+	return nil
+}
+
+// MarshalJSON implements the [json.Marshaler] interface.
+func (m RawMessage) MarshalJSON() ([]byte, error) {
+	if m.value != nil {
+		return json.Marshal(m.value)
+	}
+	if m.json == nil {
+		return []byte("null"), nil
+	}
+	return m.json, nil
+}
+
+// UnmarshalJSON implements the [json.Marshaler] interface.
+func (m *RawMessage) UnmarshalJSON(data []byte) error {
+	if m.yaml != nil {
+		return fmt.Errorf("%T: ambigous state, data was already unmarshalled using YAML encoding", m)
+	}
+	if m == nil {
+		return fmt.Errorf("%T: UnmarshalJSON on nil pointer", m)
+	}
+	m.json = append(m.json[0:0], data...)
+	return nil
+}

--- a/pkg/openslo/raw_message.go
+++ b/pkg/openslo/raw_message.go
@@ -10,8 +10,14 @@ import (
 
 // NewRawMessage creates a new [RawMessage] and sets a value the message will hold.
 // When any of the marshalling methods are called, the value provided value will be encoded.
-func NewRawMessage(v any) RawMessage {
-	return RawMessage{value: v}
+func NewRawMessage(v any) *RawMessage {
+	switch v := v.(type) {
+	case *yaml.Node:
+		return &RawMessage{yaml: v}
+	case []byte:
+		return &RawMessage{json: v}
+	}
+	return &RawMessage{value: v}
 }
 
 // RawMessage holds either JSON or YAML raw value.

--- a/pkg/openslo/raw_message_test.go
+++ b/pkg/openslo/raw_message_test.go
@@ -1,0 +1,102 @@
+package openslo
+
+import (
+	"encoding/json"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+type dataSourceSpec struct {
+	Type              string     `yaml:"type" json:"type"`
+	ConnectionDetails RawMessage `yaml:"connectionDetails" json:"connectionDetails"`
+}
+
+type connectionDetails struct {
+	Password string `yaml:"password" json:"password"`
+}
+
+func TestRawMessage(t *testing.T) {
+	tests := map[string]struct {
+		in            string
+		marshalFunc   func(v interface{}) ([]byte, error)
+		unmarshalFunc func(data []byte, v interface{}) error
+	}{
+		"YAML": {
+			in: `type: prometheus
+connectionDetails:
+    password: password
+`,
+			marshalFunc:   yaml.Marshal,
+			unmarshalFunc: yaml.Unmarshal,
+		},
+		"JSON": {
+			in:            `{"type":"prometheus","connectionDetails":{"password":"password"}}`,
+			marshalFunc:   json.Marshal,
+			unmarshalFunc: json.Unmarshal,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var spec dataSourceSpec
+			err := tc.unmarshalFunc([]byte(tc.in), &spec)
+			if err != nil {
+				failf(t, "error: %v", err)
+			}
+			data, err := tc.marshalFunc(spec)
+			if err != nil {
+				failf(t, "error: %v", err)
+			}
+			if string(data) != tc.in {
+				failf(t, "unexpected data:\nEXPECTD:\n%s\nACTUAL:\n%s", tc.in, data)
+			}
+			var details connectionDetails
+			if err = spec.ConnectionDetails.Unmarshal(&details); err != nil {
+				failf(t, "error: %v", err)
+			}
+			if details.Password != "password" {
+				failf(t, "unexpected password")
+			}
+		})
+	}
+}
+
+func TestNewRawMessage(t *testing.T) {
+	spec := dataSourceSpec{
+		Type: "prometheus",
+		ConnectionDetails: NewRawMessage(connectionDetails{
+			Password: "password",
+		}),
+	}
+	for name, tc := range map[string]struct {
+		expected    string
+		marshalFunc func(v interface{}) ([]byte, error)
+	}{
+		"YAML": {
+			expected: `type: prometheus
+connectionDetails:
+    password: password
+`,
+			marshalFunc: yaml.Marshal,
+		},
+		"JSON": {
+			expected:    `{"type":"prometheus","connectionDetails":{"password":"password"}}`,
+			marshalFunc: json.Marshal,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			data, err := tc.marshalFunc(spec)
+			if err != nil {
+				failf(t, "error: %v", err)
+			}
+			if string(data) != tc.expected {
+				failf(t, "unexpected data:\nEXPECTED:\n%s\nACTUAL:\n%s", tc.expected, data)
+			}
+		})
+	}
+}
+
+func failf(t *testing.T, format string, args ...interface{}) {
+	t.Errorf(format, args...)
+	t.FailNow()
+}

--- a/pkg/openslo/raw_message_test.go
+++ b/pkg/openslo/raw_message_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 type dataSourceSpec struct {
-	Type              string     `yaml:"type" json:"type"`
-	ConnectionDetails RawMessage `yaml:"connectionDetails" json:"connectionDetails"`
+	Type              string      `yaml:"type" json:"type"`
+	ConnectionDetails *RawMessage `yaml:"connectionDetails" json:"connectionDetails"`
 }
 
 type connectionDetails struct {
@@ -41,21 +41,21 @@ connectionDetails:
 			var spec dataSourceSpec
 			err := tc.unmarshalFunc([]byte(tc.in), &spec)
 			if err != nil {
-				failf(t, "error: %v", err)
+				t.Fatalf("error: %v", err)
 			}
 			data, err := tc.marshalFunc(spec)
 			if err != nil {
-				failf(t, "error: %v", err)
+				t.Fatalf("error: %v", err)
 			}
 			if string(data) != tc.in {
-				failf(t, "unexpected data:\nEXPECTD:\n%s\nACTUAL:\n%s", tc.in, data)
+				t.Fatalf("unexpected data:\nEXPECTD:\n%s\nACTUAL:\n%s", tc.in, data)
 			}
 			var details connectionDetails
 			if err = spec.ConnectionDetails.Unmarshal(&details); err != nil {
-				failf(t, "error: %v", err)
+				t.Fatalf("error: %v", err)
 			}
 			if details.Password != "password" {
-				failf(t, "unexpected password")
+				t.Fatalf("unexpected password")
 			}
 		})
 	}
@@ -87,16 +87,11 @@ connectionDetails:
 		t.Run(name, func(t *testing.T) {
 			data, err := tc.marshalFunc(spec)
 			if err != nil {
-				failf(t, "error: %v", err)
+				t.Fatalf("error: %v", err)
 			}
 			if string(data) != tc.expected {
-				failf(t, "unexpected data:\nEXPECTED:\n%s\nACTUAL:\n%s", tc.expected, data)
+				t.Fatalf("unexpected data:\nEXPECTED:\n%s\nACTUAL:\n%s", tc.expected, data)
 			}
 		})
 	}
-}
-
-func failf(t *testing.T, format string, args ...interface{}) {
-	t.Errorf(format, args...)
-	t.FailNow()
 }

--- a/pkg/openslo/v1/data_source.go
+++ b/pkg/openslo/v1/data_source.go
@@ -1,6 +1,8 @@
 package v1
 
-import "github.com/OpenSLO/OpenSLO/pkg/openslo"
+import (
+	"github.com/OpenSLO/OpenSLO/pkg/openslo"
+)
 
 var _ = openslo.Object(DataSource{})
 
@@ -28,6 +30,6 @@ func (d DataSource) Validate() error {
 }
 
 type DataSourceSpec struct {
-	Type              string            `yaml:"type"`
-	ConnectionDetails map[string]string `yaml:"connectionDetails"`
+	Type              string             `yaml:"type"`
+	ConnectionDetails openslo.RawMessage `yaml:"connectionDetails"`
 }

--- a/pkg/openslo/v1/data_source_example_test.go
+++ b/pkg/openslo/v1/data_source_example_test.go
@@ -1,0 +1,55 @@
+package v1_test
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/OpenSLO/OpenSLO/pkg/openslo"
+	v1 "github.com/OpenSLO/OpenSLO/pkg/openslo/v1"
+	"github.com/OpenSLO/OpenSLO/pkg/openslosdk"
+)
+
+type prometheusConnectionDetails struct {
+	URL       string `json:"url"`
+	BasicAuth string `json:"basicAuth"`
+}
+
+func ExampleDataSource() {
+	dataSource := v1.DataSource{
+		APIVersion: openslo.VersionV1,
+		Kind:       openslo.KindDataSource,
+		Metadata: v1.Metadata{
+			Name:        "promehteus",
+			DisplayName: "Prometheus",
+			Labels: map[string]v1.Label{
+				"env": {"prod"},
+			},
+		},
+		Spec: v1.DataSourceSpec{
+			Type: "Prometheus",
+			ConnectionDetails: openslo.NewRawMessage(prometheusConnectionDetails{
+				URL:       "https://prometheus.example.com",
+				BasicAuth: "secret",
+			}),
+		},
+	}
+
+	if err := openslosdk.Encode(os.Stdout, openslosdk.FormatYAML, dataSource); err != nil {
+		fmt.Println(err)
+	}
+	// Output:
+	// apiVersion: openslo/v1
+	// kind: DataSource
+	// metadata:
+	//   name: promehteus
+	//   displayName: Prometheus
+	//   labels:
+	//     env:
+	//       - prod
+	//   annotations: {}
+	// spec:
+	//   type: Prometheus
+	//   connectionDetails:
+	//     url: https://prometheus.example.com
+	//     basicauth: secret
+}

--- a/pkg/openslo/v2alpha1/data_source.go
+++ b/pkg/openslo/v2alpha1/data_source.go
@@ -1,6 +1,12 @@
 package v2alpha1
 
-import "github.com/OpenSLO/OpenSLO/pkg/openslo"
+import (
+	"encoding/json"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/OpenSLO/OpenSLO/pkg/openslo"
+)
 
 var _ = openslo.Object(DataSource{})
 
@@ -28,8 +34,71 @@ func (d DataSource) Validate() error {
 }
 
 type DataSourceSpec struct {
-	Description                 string `yaml:"description,omitempty"`
-	DataSourceConnectionDetails `yaml:",inline"`
+	Description string `yaml:"description,omitempty"`
+	DataSourceConnectionDetails
 }
 
-type DataSourceConnectionDetails = openslo.RawMessage
+type DataSourceConnectionDetails = *openslo.RawMessage
+
+func (d *DataSourceSpec) UnmarshalYAML(value *yaml.Node) error {
+	var spec map[string]*yaml.Node
+	if err := value.Decode(&spec); err != nil {
+		return err
+	}
+	if spec["description"] != nil {
+		if err := spec["description"].Decode(&d.Description); err != nil {
+			return err
+		}
+	}
+	delete(spec, "description")
+	d.DataSourceConnectionDetails = openslo.NewRawMessage(value)
+	return nil
+}
+
+// FIXME: Here's the catch! We do not operate on raw bytes...
+func (d DataSourceSpec) MarshalYAML() (interface{}, error) {
+	rawSpec, err := d.DataSourceConnectionDetails.MarshalYAML()
+	if err != nil {
+		return nil, err
+	}
+	spec := make(map[string]*yaml.Node)
+	if d.Description != "" {
+		spec["description"] = &yaml.Node{Kind: yaml.ScalarNode, Value: d.Description}
+	}
+	for k, v := range rawSpec.(map[string]*yaml.Node) {
+		spec[k] = v
+	}
+	return spec, nil
+}
+
+func (d *DataSourceSpec) UnmarshalJSON(bytes []byte) error {
+	var spec map[string]json.RawMessage
+	if err := json.Unmarshal(bytes, &spec); err != nil {
+		return err
+	}
+	if spec["description"] != nil {
+		if err := json.Unmarshal(spec["description"], &d.Description); err != nil {
+			return err
+		}
+	}
+	delete(spec, "description")
+	specBytes, err := json.Marshal(spec)
+	if err != nil {
+		return err
+	}
+	d.DataSourceConnectionDetails = openslo.NewRawMessage(specBytes)
+	return nil
+}
+
+func (d DataSourceSpec) MarshalJSON() ([]byte, error) {
+	rawSpec, err := d.DataSourceConnectionDetails.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+	var spec map[string]json.RawMessage
+	if err = json.Unmarshal(rawSpec, &spec); err != nil {
+		return nil, err
+	}
+	spec["description"], _ = json.Marshal(d.Description)
+	return json.Marshal(spec)
+}

--- a/pkg/openslo/v2alpha1/data_source.go
+++ b/pkg/openslo/v2alpha1/data_source.go
@@ -32,4 +32,4 @@ type DataSourceSpec struct {
 	DataSourceConnectionDetails `yaml:",inline"`
 }
 
-type DataSourceConnectionDetails map[string]any
+type DataSourceConnectionDetails = openslo.RawMessage

--- a/pkg/openslo/v2alpha1/data_source_test.go
+++ b/pkg/openslo/v2alpha1/data_source_test.go
@@ -1,0 +1,55 @@
+package v2alpha1
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/OpenSLO/OpenSLO/pkg/openslo"
+)
+
+func TestDataSourceSpec_JSON(t *testing.T) {
+	spec := DataSourceSpec{
+		Description:                 "this",
+		DataSourceConnectionDetails: openslo.NewRawMessage(map[string]any{"key": "value"}),
+	}
+	data, err := json.Marshal(spec)
+	if err != nil {
+		t.Fatalf("failed to marshal spec: %v", err)
+	}
+	if string(data) != `{"description":"this","key":"value"}` {
+		t.Fatalf("unexpected data: %s", data)
+	}
+	var decoded DataSourceSpec
+	if err = json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal data: %v", err)
+	}
+	if reflect.DeepEqual(spec, decoded) {
+		t.Fatalf("decoded data does not match original")
+	}
+}
+
+func TestDataSourceSpec_YAML(t *testing.T) {
+	spec := DataSourceSpec{
+		Description:                 "this",
+		DataSourceConnectionDetails: openslo.NewRawMessage(map[string]any{"key": "value"}),
+	}
+	data, err := yaml.Marshal(spec)
+	if err != nil {
+		t.Fatalf("failed to marshal spec: %v", err)
+	}
+	if string(data) != `description: this
+key: value
+` {
+		t.Fatalf("unexpected data: %s", data)
+	}
+	var decoded DataSourceSpec
+	if err = yaml.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal data: %v", err)
+	}
+	if reflect.DeepEqual(spec, decoded) {
+		t.Fatalf("decoded data does not match original")
+	}
+}

--- a/pkg/openslo/v2alpha1/sli.go
+++ b/pkg/openslo/v2alpha1/sli.go
@@ -46,5 +46,5 @@ type SLIRatioMetric struct {
 type SLIMetricSpec struct {
 	DataSourceRef               string         `yaml:"dataSourceRef,omitempty"`
 	DataSourceSpec              map[string]any `yaml:"spec,omitempty"`
-	DataSourceConnectionDetails `yaml:",inline"`
+	DataSourceConnectionDetails any
 }

--- a/pkg/openslosdk/encoding.go
+++ b/pkg/openslosdk/encoding.go
@@ -25,7 +25,7 @@ func Decode(r io.Reader, format ObjectFormat) ([]openslo.Object, error) {
 	}
 }
 
-func Encode(out io.Writer, format ObjectFormat, objects []openslo.Object) error {
+func Encode(out io.Writer, format ObjectFormat, objects ...openslo.Object) error {
 	if err := format.Validate(); err != nil {
 		return err
 	}
@@ -33,7 +33,13 @@ func Encode(out io.Writer, format ObjectFormat, objects []openslo.Object) error 
 	case FormatYAML:
 		enc := yaml.NewEncoder(out)
 		enc.SetIndent(2)
-		if err := enc.Encode(objects); err != nil {
+		var err error
+		if len(objects) == 1 {
+			err = enc.Encode(objects[0])
+		} else {
+			err = enc.Encode(objects)
+		}
+		if err != nil {
 			return fmt.Errorf("failed to encode objects: %w", err)
 		}
 		return nil

--- a/pkg/openslosdk/encoding_test.go
+++ b/pkg/openslosdk/encoding_test.go
@@ -158,13 +158,8 @@ func TestDecode(t *testing.T) {
 						Name: "cloudWatch-prod",
 					},
 					Spec: v2alpha1.DataSourceSpec{
-						Description: "CloudWatch Production Data Source",
-						DataSourceConnectionDetails: v2alpha1.DataSourceConnectionDetails{
-							"cloudWatch": map[string]any{
-								"accessKeyID":     "accessKey",
-								"secretAccessKey": "secretAccessKey",
-							},
-						},
+						Description:                 "CloudWatch Production Data Source",
+						DataSourceConnectionDetails: openslo.RawMessage{},
 					},
 				},
 			},
@@ -229,12 +224,7 @@ func TestDecode(t *testing.T) {
 										"databaseName": "metrics-db",
 										"query":        "SELECT value, timestamp FROM metrics WHERE timestamp BETWEEN :date_from AND :date_to",
 									},
-									DataSourceConnectionDetails: v2alpha1.DataSourceConnectionDetails{
-										"redshift": map[string]any{
-											"accessKeyID":     "accessKey",
-											"secretAccessKey": "secretAccessKey",
-										},
-									},
+									DataSourceConnectionDetails: openslo.RawMessage{},
 								},
 							},
 						},


### PR DESCRIPTION
PoC which demonstrates ways of handling inline fields with `go-yaml/yaml/v3`.