### PR TITLE
feat: Revert v2alpha SLI inlined Data Source changes

### DIFF
--- a/enhancements/v2alpha1.md
+++ b/enhancements/v2alpha1.md
@@ -12,36 +12,6 @@ in the specification to reach that goal.
 3. Adhere to [metadata.labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) and
    [metadata.annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/) Kubernetes standards.
 
-## [DataSource](../README.md#datasource)
-
-**Rationale:** Simplify syntax. Avoid being needlessly verbose without sacrificing flexibility and readability.
-
-```yaml
-apiVersion: openslo.com/v2alpha1
-kind: DataSource
-metadata:
-  name: string
-  labels: object # optional
-spec:
-  description: string # optional up to 1050 characters
-  <<dataSourceName>>: # e.g. cloudWatch, datadog, prometheus (arbitrary chosen, implementor decision)
-  # fields used for creating a connection with particular datasource e.g. AccessKeys, SecretKeys, etc.
-  # everything that is valid YAML can be put here
-```
-
-An example of the DataSource kind can be:
-
-```yaml
-apiVersion: openslo.com/v2alpha1
-kind: DataSource
-metadata:
-  name: string
-spec:
-  cloudWatch:
-    accessKeyID: accessKey
-    secretAccessKey: secretAccessKey
-```
-
 ## [SLO](../README.md#slo)
 
 **Rationale:** Make names more straightforward and aligned with others. Change field indicator to `sli` and `indicatorRef` to `sliRef`
@@ -110,7 +80,7 @@ spec:
   thresholdMetric: # either thresholdMetric or ratioMetric must be provided
     # either dataSourceRef or <<dataSourceName>> must be provided
     dataSourceRef: string # refer to already defined DataSource object
-    <<dataSourceName>>: # inline whole DataSource e.g. cloudWatch, datadog, prometheus (arbitrary chosen, implementor decision)
+    dataSource: # contains whole DataSource "spec"
   # fields used for creating a connection with particular datasource e.g. AccessKeys, SecretKeys, etc.
   # everything that is valid YAML can be put here
     spec:
@@ -124,7 +94,7 @@ spec:
     good: # the numerator, either "good" or "bad" must be provided if "total" is used
       # either dataSourceRef or <<dataSourceName>> must be provided
       dataSourceRef: string # refer to already defined DataSource object
-      <<dataSourceName>>: # inline whole DataSource e.g. cloudWatch, datadog, prometheus (arbitrary chosen, implementor decision)
+      dataSource: # contains whole DataSource "spec"
    # fields used for creating a connection with particular datasource e.g. AccessKeys, SecretKeys, etc.
    # everything that is valid YAML can be put here
       spec:
@@ -133,7 +103,7 @@ spec:
     bad: # the numerator, either "good" or "bad" must be provided if "total" is used
       # either dataSourceRef or <<dataSourceName>> must be provided
       dataSourceRef: string # refer to already defined DataSource object
-      <<dataSourceName>>: # inline whole DataSource e.g. cloudWatch, datadog, prometheus (arbitrary chosen, implementor decision)
+      dataSource: # contains whole DataSource "spec"
    # fields used for creating a connection with particular datasource e.g. AccessKeys, SecretKeys, etc.
    # everything that is valid YAML can be put here
       spec:
@@ -142,7 +112,7 @@ spec:
     total: # the denominator used with either "good" or "bad", either this or "raw" must be used
       # either dataSourceRef or <<dataSourceName>> must be provided
       dataSourceRef: string # refer to already defined DataSource object
-      <<dataSourceName>>: # inline whole DataSource e.g. cloudWatch, datadog, prometheus (arbitrary chosen, implementor decision)
+      dataSource: # contains whole DataSource "spec"
    # fields used for creating a connection with particular datasource e.g. AccessKeys, SecretKeys, etc.
    # everything that is valid YAML can be put here
       spec:
@@ -156,7 +126,7 @@ spec:
     raw: # the precomputed ratio stored as a metric, can't be used together with good/bad/total
       # either dataSourceRef or <<dataSourceName>> must be provided
       dataSourceRef: string # refer to already defined DataSource object
-      <<dataSourceName>>:# inline whole DataSource e.g. cloudWatch, datadog, prometheus (arbitrary chosen, implementor decision)
+      dataSource: # contains whole DataSource "spec"
         # fields used for creating a connection with particular datasource e.g. AccessKeys, SecretKeys, etc.
         # everything that is valid YAML can be put here
       spec:
@@ -223,9 +193,11 @@ An example **thresholdMetric** that does not reference a defined DataSource (it 
 
 ```yaml
 thresholdMetric:
-  redshift:
-    accessKeyID: accessKey
-    secretAccessKey: secretAccessKey
+  dataSource:
+    type: redshift
+    connetionDetails:
+      accessKeyID: accessKey
+      secretAccessKey: secretAccessKey
   spec:
     region: eu-central-1
     clusterId: metrics-cluster


### PR DESCRIPTION
## Motivation

The change introduced to v2alpha with this [PR](https://github.com/OpenSLO/OpenSLO/pull/178) which changed how a Data Source is defined in the SLI schema is proving to be problematic implementation wise.

Here's the current shape of the problematic SLI definition as defined in v1 version:

```yaml
thresholdMetric:
  metricSource:
    type: Redshift
    spec:
      region: eu-central-1
      clusterId: metrics-cluster
      databaseName: metrics-db
      query: SELECT value, timestamp FROM metrics WHERE timestamp BETWEEN :date_from AND :date_to
      accessKeyID: accessKey
      secretAccessKey: secretAccessKey
```

And here's the v2alpha proposal:

```yaml
thresholdMetric:
  redshift:
    accessKeyID: accessKey
    secretAccessKey: secretAccessKey
  spec:
    region: eu-central-1
    clusterId: metrics-cluster
    databaseName: metrics-db
    query: SELECT value, timestamp FROM metrics WHERE timestamp BETWEEN :date_from AND :date_to
```

I agree the PR does move into a good direction with splitting the data source details from the query details. However, I'd argue that the slight ease of writing (saves literally just one line of code) improvement we gain is paid by some HEAVY lifting on the implementation side.

## What's the problem?

Mixing compile time unknown fields with predefined fields.

In the proposal we have two fields that are predefined: `spec` and `dataSourceRef`, the latter being an optional field, which does not change the fact that its type is pre-declared.

The Go representation looks like this:

```go
type SLIMetricSpec struct {
	DataSourceRef               string         `yaml:"dataSourceRef,omitempty"`
	DataSourceSpec              map[string]any `yaml:"spec,omitempty"`
	DataSourceConnectionDetails `yaml:",inline"`
}
```

- `encoding/json` does not have builtin inlining capabilities. It requires writing a custom encoding functions for `SLIMetricSpec`.
- `go-yaml/yaml` supports inlining out of the box (only for maps and structs) will suffer nonetheless in a scenario where we want to delay decoding of the inlined fields with something similar to `json.RawMessage`. In this scenario, when we implement `UnmarshalYAML` for a struct serving the same purpose as `json.RawMessage`, the inlined field will be "greedy" and it will store all the other defined fields like `dataSourceRef` or `spec`.

Furthermore, we can't just think about Go and its ecosystem.
OpenSLO schema should available to adoption in other languages as well. Making it over complicated for implementation makes that accessibility much lower.

Code generation utilities like JSON Schema or Cue will simply not work with such mix of defined and undefined fields.

Finally, I strongly believe OpenSLO should strive to be easy to implement.
We won't attract any users if the schema is not first implemented, just by itself it does not provide any value.
By making it slightly easier to write (I'd argue it might not even be much more readable, even for humans) and much harder to implement we're picking the wrong kind of trade-off.

## What do I propose?

Simply reuse Data Source `spec` in a dedicated field:

```yaml
thresholdMetric:
  dataSource:
    type: redshift
    connectionDetails:
      accessKeyID: accessKey
      secretAccessKey: secretAccessKey
  spec:
    region: eu-central-1
    clusterId: metrics-cluster
    databaseName: metrics-db
    query: SELECT value, timestamp FROM metrics WHERE timestamp BETWEEN :date_from AND :date_to
 ```

It's easy to read, allows reusability code-wise and makes it very straightforward to implement.