### PR TITLE
feat: Switch to sigs.k8s.io YAML library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/OpenSLO/OpenSLO
 
 go 1.22
 
-require gopkg.in/yaml.v3 v3.0.1
+require sigs.k8s.io/yaml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
+sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/pkg/openslo/v1/alert_condition.go
+++ b/pkg/openslo/v1/alert_condition.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(AlertCondition{})
 
 type AlertCondition struct {
-	APIVersion openslo.Version    `yaml:"apiVersion"`
-	Kind       openslo.Kind       `yaml:"kind"`
-	Metadata   Metadata           `yaml:"metadata"`
-	Spec       AlertConditionSpec `yaml:"spec"`
+	APIVersion openslo.Version    `json:"apiVersion"`
+	Kind       openslo.Kind       `json:"kind"`
+	Metadata   Metadata           `json:"metadata"`
+	Spec       AlertConditionSpec `json:"spec"`
 }
 
 func (a AlertCondition) GetVersion() openslo.Version {
@@ -28,14 +28,14 @@ func (a AlertCondition) Validate() error {
 }
 
 type AlertConditionSpec struct {
-	Severity    string             `yaml:"severity"`
-	Condition   AlertConditionType `yaml:"condition"`
-	Description string             `yaml:"description,omitempty"`
+	Severity    string             `json:"severity"`
+	Condition   AlertConditionType `json:"condition"`
+	Description string             `json:"description,omitempty"`
 }
 
 type AlertConditionType struct {
-	Kind           string  `yaml:"kind"`
-	Threshold      float64 `yaml:"threshold"`
-	LookbackWindow string  `yaml:"lookbackWindow"`
-	AlertAfter     string  `yaml:"alertAfter"`
+	Kind           string  `json:"kind"`
+	Threshold      float64 `json:"threshold"`
+	LookbackWindow string  `json:"lookbackWindow"`
+	AlertAfter     string  `json:"alertAfter"`
 }

--- a/pkg/openslo/v1/alert_notification_target.go
+++ b/pkg/openslo/v1/alert_notification_target.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(AlertNotificationTarget{})
 
 type AlertNotificationTarget struct {
-	APIVersion openslo.Version             `yaml:"apiVersion"`
-	Kind       openslo.Kind                `yaml:"kind"`
-	Metadata   Metadata                    `yaml:"metadata"`
-	Spec       AlertNotificationTargetSpec `yaml:"spec"`
+	APIVersion openslo.Version             `json:"apiVersion"`
+	Kind       openslo.Kind                `json:"kind"`
+	Metadata   Metadata                    `json:"metadata"`
+	Spec       AlertNotificationTargetSpec `json:"spec"`
 }
 
 func (a AlertNotificationTarget) GetVersion() openslo.Version {
@@ -28,6 +28,6 @@ func (a AlertNotificationTarget) Validate() error {
 }
 
 type AlertNotificationTargetSpec struct {
-	Description string `yaml:"description,omitempty"`
-	Target      string `yaml:"target"`
+	Description string `json:"description,omitempty"`
+	Target      string `json:"target"`
 }

--- a/pkg/openslo/v1/alert_policy.go
+++ b/pkg/openslo/v1/alert_policy.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(AlertPolicy{})
 
 type AlertPolicy struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       AlertPolicySpec `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       AlertPolicySpec `json:"spec"`
 }
 
 func (a AlertPolicy) GetVersion() openslo.Version {
@@ -28,29 +28,29 @@ func (a AlertPolicy) Validate() error {
 }
 
 type AlertPolicyCondition struct {
-	*AlertPolicyConditionRef    `yaml:",inline,omitempty"`
-	*AlertPolicyInlineCondition `yaml:",inline,omitempty"`
+	*AlertPolicyConditionRef    `json:",inline,omitempty"`
+	*AlertPolicyInlineCondition `json:",inline,omitempty"`
 }
 
 type AlertPolicyInlineCondition struct {
-	Kind     string             `yaml:"kind"`
-	Metadata Metadata           `yaml:"metadata"`
-	Spec     AlertConditionSpec `yaml:"spec"`
+	Kind     string             `json:"kind"`
+	Metadata Metadata           `json:"metadata"`
+	Spec     AlertConditionSpec `json:"spec"`
 }
 
 type AlertPolicyConditionRef struct {
-	ConditionRef string `yaml:"conditionRef"`
+	ConditionRef string `json:"conditionRef"`
 }
 
 type AlertPolicyNotificationTarget struct {
-	TargetRef string `yaml:"targetRef"`
+	TargetRef string `json:"targetRef"`
 }
 
 type AlertPolicySpec struct {
-	Description         string                          `yaml:"description,omitempty"`
-	AlertWhenNoData     bool                            `yaml:"alertWhenNoData"`
-	AlertWhenBreaching  bool                            `yaml:"alertWhenBreaching"`
-	AlertWhenResolved   bool                            `yaml:"alertWhenResolved"`
-	Conditions          []AlertPolicyCondition          `yaml:"conditions"`
-	NotificationTargets []AlertPolicyNotificationTarget `yaml:"notificationTargets"`
+	Description         string                          `json:"description,omitempty"`
+	AlertWhenNoData     bool                            `json:"alertWhenNoData"`
+	AlertWhenBreaching  bool                            `json:"alertWhenBreaching"`
+	AlertWhenResolved   bool                            `json:"alertWhenResolved"`
+	Conditions          []AlertPolicyCondition          `json:"conditions"`
+	NotificationTargets []AlertPolicyNotificationTarget `json:"notificationTargets"`
 }

--- a/pkg/openslo/v1/data_source.go
+++ b/pkg/openslo/v1/data_source.go
@@ -1,14 +1,18 @@
 package v1
 
-import "github.com/OpenSLO/OpenSLO/pkg/openslo"
+import (
+	"encoding/json"
+
+	"github.com/OpenSLO/OpenSLO/pkg/openslo"
+)
 
 var _ = openslo.Object(DataSource{})
 
 type DataSource struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       DataSourceSpec  `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       DataSourceSpec  `json:"spec"`
 }
 
 func (d DataSource) GetVersion() openslo.Version {
@@ -28,6 +32,6 @@ func (d DataSource) Validate() error {
 }
 
 type DataSourceSpec struct {
-	Type              string            `yaml:"type"`
-	ConnectionDetails map[string]string `yaml:"connectionDetails"`
+	Type              string          `json:"type"`
+	ConnectionDetails json.RawMessage `json:"connectionDetails"`
 }

--- a/pkg/openslo/v1/objects.go
+++ b/pkg/openslo/v1/objects.go
@@ -1,9 +1,8 @@
 package v1
 
 import (
+	"encoding/json"
 	"slices"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/OpenSLO/OpenSLO/pkg/openslo"
 )
@@ -25,8 +24,8 @@ func GetSupportedKinds() []openslo.Kind {
 }
 
 type Metadata struct {
-	Name        string      `yaml:"name"`
-	DisplayName string      `yaml:"displayName,omitempty"`
+	Name        string      `json:"name"`
+	DisplayName string      `json:"displayName,omitempty"`
 	Labels      Labels      `json:"labels,omitempty"`
 	Annotations Annotations `json:"annotations,omitempty"`
 }
@@ -37,11 +36,11 @@ type Annotations map[string]string
 
 type Label []string
 
-func (a *Label) UnmarshalYAML(value *yaml.Node) error {
+func (a *Label) UnmarshalJSON(data []byte) error {
 	var multi []string
-	if err := value.Decode(&multi); err != nil {
+	if err := json.Unmarshal(data, &multi); err != nil {
 		var single string
-		if err = value.Decode(&single); err != nil {
+		if err = json.Unmarshal(data, &single); err != nil {
 			return err
 		}
 		*a = []string{single}

--- a/pkg/openslo/v1/service.go
+++ b/pkg/openslo/v1/service.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(Service{})
 
 type Service struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       ServiceSpec     `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       ServiceSpec     `json:"spec"`
 }
 
 func (s Service) GetVersion() openslo.Version {
@@ -28,5 +28,5 @@ func (s Service) Validate() error {
 }
 
 type ServiceSpec struct {
-	Description string `yaml:"description,omitempty"`
+	Description string `json:"description,omitempty"`
 }

--- a/pkg/openslo/v1/sli.go
+++ b/pkg/openslo/v1/sli.go
@@ -7,10 +7,10 @@ import (
 var _ = openslo.Object(SLI{})
 
 type SLI struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       SLISpec         `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       SLISpec         `json:"spec"`
 }
 
 func (s SLI) GetVersion() openslo.Version {
@@ -30,25 +30,25 @@ func (s SLI) Validate() error {
 }
 
 type SLISpec struct {
-	ThresholdMetric *SLIMetricSpec `yaml:"thresholdMetric,omitempty"`
-	RatioMetric     *RatioMetric   `yaml:"ratioMetric,omitempty"`
+	ThresholdMetric *SLIMetricSpec `json:"thresholdMetric,omitempty"`
+	RatioMetric     *RatioMetric   `json:"ratioMetric,omitempty"`
 }
 
 type RatioMetric struct {
-	Counter bool           `yaml:"counter"`
-	Good    *SLIMetricSpec `yaml:"good,omitempty"`
-	Bad     *SLIMetricSpec `yaml:"bad,omitempty"`
-	Total   *SLIMetricSpec `yaml:"total,omitempty"`
-	RawType *string        `yaml:"rawType,omitempty"`
-	Raw     *SLIMetricSpec `yaml:"raw,omitempty"`
+	Counter bool           `json:"counter"`
+	Good    *SLIMetricSpec `json:"good,omitempty"`
+	Bad     *SLIMetricSpec `json:"bad,omitempty"`
+	Total   *SLIMetricSpec `json:"total,omitempty"`
+	RawType *string        `json:"rawType,omitempty"`
+	Raw     *SLIMetricSpec `json:"raw,omitempty"`
 }
 
 type SLIMetricSpec struct {
-	MetricSource SLIMetricSource `yaml:"metricSource"`
+	MetricSource SLIMetricSource `json:"metricSource"`
 }
 
 type SLIMetricSource struct {
-	MetricSourceRef  string         `yaml:"metricSourceRef,omitempty"`
-	Type             string         `yaml:"type,omitempty"`
-	MetricSourceSpec map[string]any `yaml:"spec"`
+	MetricSourceRef  string         `json:"metricSourceRef,omitempty"`
+	Type             string         `json:"type,omitempty"`
+	MetricSourceSpec map[string]any `json:"spec"`
 }

--- a/pkg/openslo/v1/slo.go
+++ b/pkg/openslo/v1/slo.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(SLO{})
 
 type SLO struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       SLOSpec         `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       SLOSpec         `json:"spec"`
 }
 
 func (s SLO) GetVersion() openslo.Version {
@@ -28,40 +28,40 @@ func (s SLO) Validate() error {
 }
 
 type SLOSpec struct {
-	Description     string        `yaml:"description,omitempty"`
-	Service         string        `yaml:"service"`
-	Indicator       *SLOIndicator `yaml:"indicator,omitempty"`
-	IndicatorRef    *string       `yaml:"indicatorRef,omitempty"`
-	BudgetingMethod string        `yaml:"budgetingMethod"`
-	TimeWindow      []TimeWindow  `yaml:"timeWindow"`
-	Objectives      []Objective   `yaml:"objectives"`
+	Description     string        `json:"description,omitempty"`
+	Service         string        `json:"service"`
+	Indicator       *SLOIndicator `json:"indicator,omitempty"`
+	IndicatorRef    *string       `json:"indicatorRef,omitempty"`
+	BudgetingMethod string        `json:"budgetingMethod"`
+	TimeWindow      []TimeWindow  `json:"timeWindow"`
+	Objectives      []Objective   `json:"objectives"`
 	// We don't make clear in the spec if this is a ref or inline.
 	// We will make it a ref for now.
 	// https://github.com/OpenSLO/OpenSLO/issues/133
-	AlertPolicies []string `yaml:"alertPolicies"`
+	AlertPolicies []string `json:"alertPolicies"`
 }
 
 type SLOIndicator struct {
-	Metadata Metadata `yaml:"metadata"`
-	Spec     SLISpec  `yaml:"spec"`
+	Metadata Metadata `json:"metadata"`
+	Spec     SLISpec  `json:"spec"`
 }
 
 type Objective struct {
-	DisplayName     string  `yaml:"displayName,omitempty"`
-	Op              string  `yaml:"op,omitempty"`
-	Value           float64 `yaml:"value,omitempty"`
-	Target          float64 `yaml:"target"`
-	TimeSliceTarget float64 `yaml:"timeSliceTarget,omitempty"`
-	TimeSliceWindow string  `yaml:"timeSliceWindow,omitempty"`
+	DisplayName     string  `json:"displayName,omitempty"`
+	Op              string  `json:"op,omitempty"`
+	Value           float64 `json:"value,omitempty"`
+	Target          float64 `json:"target"`
+	TimeSliceTarget float64 `json:"timeSliceTarget,omitempty"`
+	TimeSliceWindow string  `json:"timeSliceWindow,omitempty"`
 }
 
 type TimeWindow struct {
-	Duration  string    `yaml:"duration"`
-	IsRolling bool      `yaml:"isRolling"`
-	Calendar  *Calendar `yaml:"calendar,omitempty"`
+	Duration  string    `json:"duration"`
+	IsRolling bool      `json:"isRolling"`
+	Calendar  *Calendar `json:"calendar,omitempty"`
 }
 
 type Calendar struct {
-	StartTime string `yaml:"startTime"`
-	TimeZone  string `yaml:"timeZone"`
+	StartTime string `json:"startTime"`
+	TimeZone  string `json:"timeZone"`
 }

--- a/pkg/openslo/v1alpha/objects.go
+++ b/pkg/openslo/v1alpha/objects.go
@@ -18,6 +18,6 @@ func GetSupportedKinds() []openslo.Kind {
 }
 
 type Metadata struct {
-	Name        string `yaml:"name"`
-	DisplayName string `yaml:"displayName,omitempty"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName,omitempty"`
 }

--- a/pkg/openslo/v1alpha/service.go
+++ b/pkg/openslo/v1alpha/service.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(Service{})
 
 type Service struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       ServiceSpec     `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       ServiceSpec     `json:"spec"`
 }
 
 func (s Service) GetVersion() openslo.Version {
@@ -28,5 +28,5 @@ func (s Service) Validate() error {
 }
 
 type ServiceSpec struct {
-	Description string `yaml:"description,omitempty"`
+	Description string `json:"description,omitempty"`
 }

--- a/pkg/openslo/v1alpha/slo.go
+++ b/pkg/openslo/v1alpha/slo.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(SLO{})
 
 type SLO struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       SLOSpec         `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       SLOSpec         `json:"spec"`
 }
 
 func (s SLO) GetVersion() openslo.Version {
@@ -28,51 +28,51 @@ func (s SLO) Validate() error {
 }
 
 type SLOSpec struct {
-	TimeWindows     []TimeWindow `yaml:"timeWindows"`
-	BudgetingMethod string       `yaml:"budgetingMethod"`
-	Description     string       `yaml:"description,omitempty"`
-	Indicator       *Indicator   `yaml:"indicator"`
-	Service         string       `yaml:"service"`
+	TimeWindows     []TimeWindow `json:"timeWindows"`
+	BudgetingMethod string       `json:"budgetingMethod"`
+	Description     string       `json:"description,omitempty"`
+	Indicator       *Indicator   `json:"indicator"`
+	Service         string       `json:"service"`
 	Objectives      []Objective  `json:"objectives"`
 }
 
 type Indicator struct {
-	ThresholdMetric MetricSourceSpec `yaml:"thresholdMetric"`
+	ThresholdMetric MetricSourceSpec `json:"thresholdMetric"`
 }
 
 type MetricSourceSpec struct {
-	Source    string `yaml:"source"`
-	QueryType string `yaml:"queryType"`
-	Query     string `yaml:"query"`
+	Source    string `json:"source"`
+	QueryType string `json:"queryType"`
+	Query     string `json:"query"`
 }
 
 type Objective struct {
-	ObjectiveBase   `yaml:",inline"`
-	RatioMetrics    *RatioMetrics `yaml:"ratioMetrics"`
-	BudgetTarget    *float64      `yaml:"target"`
-	TimeSliceTarget *float64      `yaml:"timeSliceTarget,omitempty"`
-	Operator        *string       `yaml:"op,omitempty"`
+	ObjectiveBase   `json:",inline"`
+	RatioMetrics    *RatioMetrics `json:"ratioMetrics"`
+	BudgetTarget    *float64      `json:"target"`
+	TimeSliceTarget *float64      `json:"timeSliceTarget,omitempty"`
+	Operator        *string       `json:"op,omitempty"`
 }
 
 type RatioMetrics struct {
-	Good    MetricSourceSpec `yaml:"good"`
-	Total   MetricSourceSpec `yaml:"total"`
-	Counter bool             `yaml:"counter"`
+	Good    MetricSourceSpec `json:"good"`
+	Total   MetricSourceSpec `json:"total"`
+	Counter bool             `json:"counter"`
 }
 
 type ObjectiveBase struct {
-	DisplayName string  `yaml:"displayName"`
-	Value       float64 `yaml:"value"`
+	DisplayName string  `json:"displayName"`
+	Value       float64 `json:"value"`
 }
 
 type TimeWindow struct {
-	Unit      string    `yaml:"unit"`
-	Count     int       `yaml:"count"`
-	IsRolling bool      `yaml:"isRolling"`
-	Calendar  *Calendar `yaml:"calendar,omitempty"`
+	Unit      string    `json:"unit"`
+	Count     int       `json:"count"`
+	IsRolling bool      `json:"isRolling"`
+	Calendar  *Calendar `json:"calendar,omitempty"`
 }
 
 type Calendar struct {
-	StartTime string `yaml:"startTime"`
-	TimeZone  string `yaml:"timeZone"`
+	StartTime string `json:"startTime"`
+	TimeZone  string `json:"timeZone"`
 }

--- a/pkg/openslo/v2alpha1/alert_condition.go
+++ b/pkg/openslo/v2alpha1/alert_condition.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(AlertCondition{})
 
 type AlertCondition struct {
-	APIVersion openslo.Version    `yaml:"apiVersion"`
-	Kind       openslo.Kind       `yaml:"kind"`
-	Metadata   Metadata           `yaml:"metadata"`
-	Spec       AlertConditionSpec `yaml:"spec"`
+	APIVersion openslo.Version    `json:"apiVersion"`
+	Kind       openslo.Kind       `json:"kind"`
+	Metadata   Metadata           `json:"metadata"`
+	Spec       AlertConditionSpec `json:"spec"`
 }
 
 func (a AlertCondition) GetVersion() openslo.Version {
@@ -28,14 +28,14 @@ func (a AlertCondition) Validate() error {
 }
 
 type AlertConditionSpec struct {
-	Severity    string             `yaml:"severity"`
-	Condition   AlertConditionType `yaml:"condition"`
-	Description string             `yaml:"description,omitempty"`
+	Severity    string             `json:"severity"`
+	Condition   AlertConditionType `json:"condition"`
+	Description string             `json:"description,omitempty"`
 }
 
 type AlertConditionType struct {
-	Kind           string  `yaml:"kind"`
-	Threshold      float64 `yaml:"threshold"`
-	LookbackWindow string  `yaml:"lookbackWindow"`
-	AlertAfter     string  `yaml:"alertAfter"`
+	Kind           string  `json:"kind"`
+	Threshold      float64 `json:"threshold"`
+	LookbackWindow string  `json:"lookbackWindow"`
+	AlertAfter     string  `json:"alertAfter"`
 }

--- a/pkg/openslo/v2alpha1/alert_notification_target.go
+++ b/pkg/openslo/v2alpha1/alert_notification_target.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(AlertNotificationTarget{})
 
 type AlertNotificationTarget struct {
-	APIVersion openslo.Version             `yaml:"apiVersion"`
-	Kind       openslo.Kind                `yaml:"kind"`
-	Metadata   Metadata                    `yaml:"metadata"`
-	Spec       AlertNotificationTargetSpec `yaml:"spec"`
+	APIVersion openslo.Version             `json:"apiVersion"`
+	Kind       openslo.Kind                `json:"kind"`
+	Metadata   Metadata                    `json:"metadata"`
+	Spec       AlertNotificationTargetSpec `json:"spec"`
 }
 
 func (a AlertNotificationTarget) GetVersion() openslo.Version {
@@ -28,6 +28,6 @@ func (a AlertNotificationTarget) Validate() error {
 }
 
 type AlertNotificationTargetSpec struct {
-	Target      string `yaml:"target"`
-	Description string `yaml:"description,omitempty"`
+	Target      string `json:"target"`
+	Description string `json:"description,omitempty"`
 }

--- a/pkg/openslo/v2alpha1/alert_policy.go
+++ b/pkg/openslo/v2alpha1/alert_policy.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(AlertPolicy{})
 
 type AlertPolicy struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       AlertPolicySpec `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       AlertPolicySpec `json:"spec"`
 }
 
 func (a AlertPolicy) GetVersion() openslo.Version {
@@ -28,29 +28,29 @@ func (a AlertPolicy) Validate() error {
 }
 
 type AlertPolicyCondition struct {
-	*AlertPolicyConditionRef    `yaml:",inline,omitempty"`
-	*AlertPolicyInlineCondition `yaml:",inline,omitempty"`
+	*AlertPolicyConditionRef    `json:",inline,omitempty"`
+	*AlertPolicyInlineCondition `json:",inline,omitempty"`
 }
 
 type AlertPolicyInlineCondition struct {
-	Kind     string             `yaml:"kind"`
-	Metadata Metadata           `yaml:"metadata"`
-	Spec     AlertConditionSpec `yaml:"spec"`
+	Kind     string             `json:"kind"`
+	Metadata Metadata           `json:"metadata"`
+	Spec     AlertConditionSpec `json:"spec"`
 }
 
 type AlertPolicyConditionRef struct {
-	ConditionRef string `yaml:"conditionRef"`
+	ConditionRef string `json:"conditionRef"`
 }
 
 type AlertPolicyNotificationTarget struct {
-	TargetRef string `yaml:"targetRef"`
+	TargetRef string `json:"targetRef"`
 }
 
 type AlertPolicySpec struct {
-	Description         string                          `yaml:"description,omitempty"`
-	AlertWhenNoData     bool                            `yaml:"alertWhenNoData"`
-	AlertWhenBreaching  bool                            `yaml:"alertWhenBreaching"`
-	AlertWhenResolved   bool                            `yaml:"alertWhenResolved"`
-	Conditions          []AlertPolicyCondition          `yaml:"conditions"`
-	NotificationTargets []AlertPolicyNotificationTarget `yaml:"notificationTargets"`
+	Description         string                          `json:"description,omitempty"`
+	AlertWhenNoData     bool                            `json:"alertWhenNoData"`
+	AlertWhenBreaching  bool                            `json:"alertWhenBreaching"`
+	AlertWhenResolved   bool                            `json:"alertWhenResolved"`
+	Conditions          []AlertPolicyCondition          `json:"conditions"`
+	NotificationTargets []AlertPolicyNotificationTarget `json:"notificationTargets"`
 }

--- a/pkg/openslo/v2alpha1/data_source.go
+++ b/pkg/openslo/v2alpha1/data_source.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(DataSource{})
 
 type DataSource struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       DataSourceSpec  `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       DataSourceSpec  `json:"spec"`
 }
 
 func (d DataSource) GetVersion() openslo.Version {
@@ -28,8 +28,8 @@ func (d DataSource) Validate() error {
 }
 
 type DataSourceSpec struct {
-	Description                 string `yaml:"description,omitempty"`
-	DataSourceConnectionDetails `yaml:",inline"`
+	Description                 string `json:"description,omitempty"`
+	DataSourceConnectionDetails `json:",inline"`
 }
 
 type DataSourceConnectionDetails map[string]any

--- a/pkg/openslo/v2alpha1/objects.go
+++ b/pkg/openslo/v2alpha1/objects.go
@@ -1,9 +1,8 @@
 package v2alpha1
 
 import (
+	"encoding/json"
 	"slices"
-
-	"gopkg.in/yaml.v3"
 
 	"github.com/OpenSLO/OpenSLO/pkg/openslo"
 )
@@ -25,7 +24,7 @@ func GetSupportedKinds() []openslo.Kind {
 }
 
 type Metadata struct {
-	Name        string      `yaml:"name"`
+	Name        string      `json:"name"`
 	Labels      Labels      `json:"labels,omitempty"`
 	Annotations Annotations `json:"annotations,omitempty"`
 }
@@ -36,11 +35,11 @@ type Annotations map[string]string
 
 type Label []string
 
-func (a *Label) UnmarshalYAML(value *yaml.Node) error {
+func (a *Label) UnmarshalJSON(data []byte) error {
 	var multi []string
-	if err := value.Decode(&multi); err != nil {
+	if err := json.Unmarshal(data, &multi); err != nil {
 		var single string
-		if err = value.Decode(&single); err != nil {
+		if err = json.Unmarshal(data, &single); err != nil {
 			return err
 		}
 		*a = []string{single}

--- a/pkg/openslo/v2alpha1/service.go
+++ b/pkg/openslo/v2alpha1/service.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(Service{})
 
 type Service struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       ServiceSpec     `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       ServiceSpec     `json:"spec"`
 }
 
 func (s Service) GetVersion() openslo.Version {
@@ -28,5 +28,5 @@ func (s Service) Validate() error {
 }
 
 type ServiceSpec struct {
-	Description string `yaml:"description,omitempty"`
+	Description string `json:"description,omitempty"`
 }

--- a/pkg/openslo/v2alpha1/sli.go
+++ b/pkg/openslo/v2alpha1/sli.go
@@ -7,10 +7,10 @@ import (
 var _ = openslo.Object(SLI{})
 
 type SLI struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       SLISpec         `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       SLISpec         `json:"spec"`
 }
 
 func (s SLI) GetVersion() openslo.Version {
@@ -30,21 +30,21 @@ func (s SLI) Validate() error {
 }
 
 type SLISpec struct {
-	ThresholdMetric *SLIMetricSpec  `yaml:"thresholdMetric,omitempty"`
-	RatioMetric     *SLIRatioMetric `yaml:"ratioMetric,omitempty"`
+	ThresholdMetric *SLIMetricSpec  `json:"thresholdMetric,omitempty"`
+	RatioMetric     *SLIRatioMetric `json:"ratioMetric,omitempty"`
 }
 
 type SLIRatioMetric struct {
-	Counter bool           `yaml:"counter"`
-	Good    *SLIMetricSpec `yaml:"good,omitempty"`
-	Bad     *SLIMetricSpec `yaml:"bad,omitempty"`
-	Total   *SLIMetricSpec `yaml:"total,omitempty"`
-	RawType *string        `yaml:"rawType,omitempty"`
-	Raw     *SLIMetricSpec `yaml:"raw,omitempty"`
+	Counter bool           `json:"counter"`
+	Good    *SLIMetricSpec `json:"good,omitempty"`
+	Bad     *SLIMetricSpec `json:"bad,omitempty"`
+	Total   *SLIMetricSpec `json:"total,omitempty"`
+	RawType *string        `json:"rawType,omitempty"`
+	Raw     *SLIMetricSpec `json:"raw,omitempty"`
 }
 
 type SLIMetricSpec struct {
-	DataSourceRef               string         `yaml:"dataSourceRef,omitempty"`
-	DataSourceSpec              map[string]any `yaml:"spec,omitempty"`
-	DataSourceConnectionDetails `yaml:",inline"`
+	DataSourceRef               string         `json:"dataSourceRef,omitempty"`
+	DataSourceSpec              map[string]any `json:"spec,omitempty"`
+	DataSourceConnectionDetails `json:",inline"`
 }

--- a/pkg/openslo/v2alpha1/slo.go
+++ b/pkg/openslo/v2alpha1/slo.go
@@ -5,10 +5,10 @@ import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 var _ = openslo.Object(SLO{})
 
 type SLO struct {
-	APIVersion openslo.Version `yaml:"apiVersion"`
-	Kind       openslo.Kind    `yaml:"kind"`
-	Metadata   Metadata        `yaml:"metadata"`
-	Spec       SLOSpec         `yaml:"spec"`
+	APIVersion openslo.Version `json:"apiVersion"`
+	Kind       openslo.Kind    `json:"kind"`
+	Metadata   Metadata        `json:"metadata"`
+	Spec       SLOSpec         `json:"spec"`
 }
 
 func (s SLO) GetVersion() openslo.Version {
@@ -28,45 +28,45 @@ func (s SLO) Validate() error {
 }
 
 type SLOSpec struct {
-	Description     string          `yaml:"description,omitempty"`
-	Service         string          `yaml:"service"`
-	SLI             *SLOEmbeddedSLI `yaml:"sli,omitempty"`
-	SLIRef          *string         `yaml:"sliRef,omitempty"`
-	BudgetingMethod string          `yaml:"budgetingMethod"`
-	TimeWindow      []TimeWindow    `yaml:"timeWindow"`
-	Objectives      []Objective     `yaml:"objectives"`
+	Description     string          `json:"description,omitempty"`
+	Service         string          `json:"service"`
+	SLI             *SLOEmbeddedSLI `json:"sli,omitempty"`
+	SLIRef          *string         `json:"sliRef,omitempty"`
+	BudgetingMethod string          `json:"budgetingMethod"`
+	TimeWindow      []TimeWindow    `json:"timeWindow"`
+	Objectives      []Objective     `json:"objectives"`
 	// We don't make clear in the spec if this is a ref or inline.
 	// We will make it a ref for now.
 	// https://github.com/OpenSLO/OpenSLO/issues/133
-	AlertPolicies []string `yaml:"alertPolicies"`
+	AlertPolicies []string `json:"alertPolicies"`
 }
 
 type SLOEmbeddedSLI struct {
-	Metadata Metadata `yaml:"metadata"`
-	Spec     SLISpec  `yaml:"spec"`
+	Metadata Metadata `json:"metadata"`
+	Spec     SLISpec  `json:"spec"`
 }
 
 type Objective struct {
-	DisplayName     string          `yaml:"displayName,omitempty"`
-	Labels          Labels          `yaml:"labels,omitempty"`
-	Op              string          `yaml:"op,omitempty"`
-	Value           *float64        `yaml:"value,omitempty"`
-	Target          *float64        `yaml:"target,omitempty"`
-	TargetPercent   *float64        `yaml:"targetPercent,omitempty"`
-	TimeSliceTarget *float64        `yaml:"timeSliceTarget,omitempty"`
-	TimeSliceWindow *string         `yaml:"timeSliceWindow,omitempty"`
-	SLI             *SLOEmbeddedSLI `yaml:"sli,omitempty"`
-	SLIRef          string          `yaml:"sliRef,omitempty"`
-	CompositeWeight *float64        `yaml:"compositeWeight,omitempty"`
+	DisplayName     string          `json:"displayName,omitempty"`
+	Labels          Labels          `json:"labels,omitempty"`
+	Op              string          `json:"op,omitempty"`
+	Value           *float64        `json:"value,omitempty"`
+	Target          *float64        `json:"target,omitempty"`
+	TargetPercent   *float64        `json:"targetPercent,omitempty"`
+	TimeSliceTarget *float64        `json:"timeSliceTarget,omitempty"`
+	TimeSliceWindow *string         `json:"timeSliceWindow,omitempty"`
+	SLI             *SLOEmbeddedSLI `json:"sli,omitempty"`
+	SLIRef          string          `json:"sliRef,omitempty"`
+	CompositeWeight *float64        `json:"compositeWeight,omitempty"`
 }
 
 type TimeWindow struct {
-	Duration  string    `yaml:"duration"`
-	IsRolling bool      `yaml:"isRolling"`
-	Calendar  *Calendar `yaml:"calendar,omitempty"`
+	Duration  string    `json:"duration"`
+	IsRolling bool      `json:"isRolling"`
+	Calendar  *Calendar `json:"calendar,omitempty"`
 }
 
 type Calendar struct {
-	StartTime string `yaml:"startTime"`
-	TimeZone  string `yaml:"timeZone"`
+	StartTime string `json:"startTime"`
+	TimeZone  string `json:"timeZone"`
 }

--- a/pkg/openslosdk/encoding.go
+++ b/pkg/openslosdk/encoding.go
@@ -1,11 +1,15 @@
 package openslosdk
 
 import (
+	"bufio"
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
-	"slices"
+	"regexp"
+	"strings"
 
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/yaml"
 
 	"github.com/OpenSLO/OpenSLO/pkg/openslo"
 	v1 "github.com/OpenSLO/OpenSLO/pkg/openslo/v1"
@@ -20,6 +24,8 @@ func Decode(r io.Reader, format ObjectFormat) ([]openslo.Object, error) {
 	switch format {
 	case FormatYAML:
 		return decodeYAML(r)
+	case FormatJSON:
+		return decodeJSON(r)
 	default:
 		return nil, fmt.Errorf("unsupported %[1]T: %[1]s", format)
 	}
@@ -31,10 +37,19 @@ func Encode(out io.Writer, format ObjectFormat, objects []openslo.Object) error 
 	}
 	switch format {
 	case FormatYAML:
-		enc := yaml.NewEncoder(out)
-		enc.SetIndent(2)
+		data, err := yaml.Marshal(objects)
+		if err != nil {
+			return fmt.Errorf("failed to encode objects to YAML: %w", err)
+		}
+		if _, err = out.Write(data); err != nil {
+			return fmt.Errorf("failed to write YAML data: %w", err)
+		}
+		return nil
+	case FormatJSON:
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
 		if err := enc.Encode(objects); err != nil {
-			return fmt.Errorf("failed to encode objects: %w", err)
+			return fmt.Errorf("failed to encode objects to JSON: %w", err)
 		}
 		return nil
 	default:
@@ -42,116 +57,135 @@ func Encode(out io.Writer, format ObjectFormat, objects []openslo.Object) error 
 	}
 }
 
-type yamlDocument struct {
-	node *yaml.Node
-}
-
-func (n *yamlDocument) UnmarshalYAML(node *yaml.Node) error {
-	n.node = node
-	return nil
-}
-
 type genericObject struct {
 	apiVersion openslo.Version
 	kind       openslo.Kind
-	node       *yaml.Node
+	data       json.RawMessage
 }
 
-func (o *genericObject) UnmarshalYAML(node *yaml.Node) error {
+func (o *genericObject) UnmarshalJSON(data []byte) error {
 	var tmp struct {
-		APIVersion openslo.Version `yaml:"apiVersion"`
-		Kind       openslo.Kind    `yaml:"kind"`
+		APIVersion openslo.Version `json:"apiVersion"`
+		Kind       openslo.Kind    `json:"kind"`
 	}
-	if err := node.Decode(&tmp); err != nil {
+	if err := json.Unmarshal(data, &tmp); err != nil {
 		return fmt.Errorf("failed to unmarshal object: %w", err)
 	}
 	o.apiVersion = tmp.APIVersion
 	o.kind = tmp.Kind
-	o.node = node
+	o.data = data
 	return nil
 }
 
 func decodeYAML(r io.Reader) ([]openslo.Object, error) {
-	var docs []yamlDocument
-	dec := yaml.NewDecoder(r)
-	for {
-		var doc yamlDocument
-		if err := dec.Decode(&doc); err != nil {
-			if err == io.EOF {
-				break
-			}
-			return nil, fmt.Errorf("failed to decode YAML document: %w", err)
-		}
-		docs = append(docs, doc)
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read data: %w", err)
 	}
-
-	var objects []openslo.Object
-	for _, doc := range docs {
-		var genericObjects []genericObject
-		switch doc.node.Kind {
-		case yaml.SequenceNode:
-			if err := doc.node.Decode(&genericObjects); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal objects: %w", err)
+	scanner := bufio.NewScanner(bytes.NewBuffer(data))
+	// Documents can have any size, at most it will be the whole data.
+	// This means sometimes we might exceed the limit imposed by bufio.Scanner.
+	maxTokenSize := len(data) + 1
+	scanner.Buffer(make([]byte, 0, len(data)), maxTokenSize)
+	scanner.Split(splitYAMLDocument)
+	var genericObjects []genericObject
+	for scanner.Scan() {
+		doc := scanner.Bytes()
+		if len(bytes.TrimSpace(doc)) == 0 {
+			continue
+		}
+		switch getYamlIdent(doc) {
+		case identArray:
+			var a []genericObject
+			if err = yaml.Unmarshal(doc, &a); err != nil {
+				return nil, err
 			}
-		case yaml.MappingNode:
+			genericObjects = append(genericObjects, a...)
+		case identObject:
 			var object genericObject
-			if err := doc.node.Decode(&object); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal object: %w", err)
+			if err = yaml.Unmarshal(doc, &object); err != nil {
+				return nil, err
 			}
 			genericObjects = append(genericObjects, object)
+		}
+	}
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+	return decodeGenericObjects(genericObjects)
+}
+
+func decodeJSON(r io.Reader) ([]openslo.Object, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read data: %w", err)
+	}
+	var genericObjects []genericObject
+	switch getJsonIdent(data) {
+	case identArray:
+		if err = json.Unmarshal(data, &genericObjects); err != nil {
+			return nil, err
+		}
+	case identObject:
+		var object genericObject
+		if err = json.Unmarshal(data, &object); err != nil {
+			return nil, err
+		}
+		genericObjects = append(genericObjects, object)
+	}
+	return decodeGenericObjects(genericObjects)
+}
+
+func decodeGenericObjects(genericObjects []genericObject) ([]openslo.Object, error) {
+	objects := make([]openslo.Object, 0, len(genericObjects))
+	var decodeFunc func(genericObject) (openslo.Object, error)
+	for _, obj := range genericObjects {
+		switch obj.apiVersion {
+		case openslo.VersionV1alpha:
+			decodeFunc = decodeV1alphaObject
+		case openslo.VersionV1:
+			decodeFunc = decodeV1Object
+		case openslo.VersionV2alpha1:
+			decodeFunc = decodeV2alphaObject
 		default:
-			return nil, fmt.Errorf("unexpected YAML node: %s", doc.node.Tag)
+			return nil, fmt.Errorf("unsupported %[1]T: %[1]s", obj.apiVersion)
 		}
-		objects = slices.Grow(objects, len(genericObjects))
-		var decodeFunc func(genericObject) (openslo.Object, error)
-		for _, obj := range genericObjects {
-			switch obj.apiVersion {
-			case openslo.VersionV1alpha:
-				decodeFunc = decodeV1alphaYAMLObject
-			case openslo.VersionV1:
-				decodeFunc = decodeV1YAMLObject
-			case openslo.VersionV2alpha1:
-				decodeFunc = decodeV2alphaObject
-			default:
-				return nil, fmt.Errorf("unsupported %[1]T: %[1]s", obj.apiVersion)
-			}
-			object, err := decodeFunc(obj)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode %s %s: %w", obj.apiVersion, obj.kind, err)
-			}
-			objects = append(objects, object)
+		object, err := decodeFunc(obj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode %s %s: %w", obj.apiVersion, obj.kind, err)
 		}
+		objects = append(objects, object)
 	}
 	return objects, nil
 }
 
-func decodeV1alphaYAMLObject(generic genericObject) (openslo.Object, error) {
+func decodeV1alphaObject(generic genericObject) (openslo.Object, error) {
 	switch generic.kind {
 	case openslo.KindService:
-		return decodeYAMLObject[v1alpha.Service](generic.node)
+		return decodeJSONObject[v1alpha.Service](generic.data)
 	case openslo.KindSLO:
-		return decodeYAMLObject[v1alpha.SLO](generic.node)
+		return decodeJSONObject[v1alpha.SLO](generic.data)
 	default:
 		return nil, fmt.Errorf("unsupported %[1]T: %[1]s for version: %[2]s", generic.kind, generic.apiVersion)
 	}
 }
 
-func decodeV1YAMLObject(generic genericObject) (openslo.Object, error) {
+func decodeV1Object(generic genericObject) (openslo.Object, error) {
 	switch generic.kind {
 	case openslo.KindService:
-		return decodeYAMLObject[v1.Service](generic.node)
+		return decodeJSONObject[v1.Service](generic.data)
 	case openslo.KindSLO:
-		return decodeYAMLObject[v1.SLO](generic.node)
+		return decodeJSONObject[v1.SLO](generic.data)
 	case openslo.KindSLI:
-		return decodeYAMLObject[v1.SLI](generic.node)
+		return decodeJSONObject[v1.SLI](generic.data)
 	case openslo.KindDataSource:
-		return decodeYAMLObject[v1.DataSource](generic.node)
+		return decodeJSONObject[v1.DataSource](generic.data)
 	case openslo.KindAlertPolicy:
-		return decodeYAMLObject[v1.AlertPolicy](generic.node)
+		return decodeJSONObject[v1.AlertPolicy](generic.data)
 	case openslo.KindAlertCondition:
-		return decodeYAMLObject[v1.AlertCondition](generic.node)
+		return decodeJSONObject[v1.AlertCondition](generic.data)
 	case openslo.KindAlertNotificationTarget:
-		return decodeYAMLObject[v1.AlertNotificationTarget](generic.node)
+		return decodeJSONObject[v1.AlertNotificationTarget](generic.data)
 	default:
 		return nil, fmt.Errorf("unsupported %[1]T: %[1]s for version: %[2]s", generic.kind, generic.apiVersion)
 	}
@@ -160,28 +194,101 @@ func decodeV1YAMLObject(generic genericObject) (openslo.Object, error) {
 func decodeV2alphaObject(generic genericObject) (openslo.Object, error) {
 	switch generic.kind {
 	case openslo.KindService:
-		return decodeYAMLObject[v2alpha1.Service](generic.node)
+		return decodeJSONObject[v2alpha1.Service](generic.data)
 	case openslo.KindSLO:
-		return decodeYAMLObject[v2alpha1.SLO](generic.node)
+		return decodeJSONObject[v2alpha1.SLO](generic.data)
 	case openslo.KindSLI:
-		return decodeYAMLObject[v2alpha1.SLI](generic.node)
+		return decodeJSONObject[v2alpha1.SLI](generic.data)
 	case openslo.KindDataSource:
-		return decodeYAMLObject[v2alpha1.DataSource](generic.node)
+		return decodeJSONObject[v2alpha1.DataSource](generic.data)
 	case openslo.KindAlertPolicy:
-		return decodeYAMLObject[v2alpha1.AlertPolicy](generic.node)
+		return decodeJSONObject[v2alpha1.AlertPolicy](generic.data)
 	case openslo.KindAlertCondition:
-		return decodeYAMLObject[v2alpha1.AlertCondition](generic.node)
+		return decodeJSONObject[v2alpha1.AlertCondition](generic.data)
 	case openslo.KindAlertNotificationTarget:
-		return decodeYAMLObject[v2alpha1.AlertNotificationTarget](generic.node)
+		return decodeJSONObject[v2alpha1.AlertNotificationTarget](generic.data)
 	default:
 		return nil, fmt.Errorf("unsupported %[1]T: %[1]s for version: %[2]s", generic.kind, generic.apiVersion)
 	}
 }
 
-func decodeYAMLObject[T openslo.Object](node *yaml.Node) (T, error) {
+func decodeJSONObject[T openslo.Object](data json.RawMessage) (T, error) {
 	var object T
-	if err := node.Decode(&object); err != nil {
+	if err := json.Unmarshal(data, &object); err != nil {
 		return object, err
 	}
 	return object, nil
+}
+
+type ident uint8
+
+const (
+	identArray = iota + 1
+	identObject
+)
+
+var jsonArrayIdentRegex = regexp.MustCompile(`^\s*\[`)
+
+func getJsonIdent(data []byte) ident {
+	if jsonArrayIdentRegex.Match(data) {
+		return identArray
+	}
+	return identObject
+}
+
+// For a valid array, the first non-whitespace, non-comment character must be a dash or a bracket.
+func getYamlIdent(data []byte) ident {
+	scanner := bufio.NewScanner(bytes.NewBuffer(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if len(line) == 0 {
+			continue
+		}
+		switch line[0] {
+		case '#':
+			continue
+		case '[':
+			return identArray
+		case '-':
+			if line == "---" {
+				continue
+			}
+			return identArray
+		}
+		break
+	}
+	return identObject
+}
+
+// yamlDocSep includes a prefixed newline character as we do now want to split on the first
+// document separator located at the beginning of the file.
+const yamlDocSep = "\n---"
+
+// splitYAMLDocument is a bufio.SplitFunc for splitting YAML streams into individual documents.
+func splitYAMLDocument(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	// We have a potential document terminator.
+	if i := bytes.Index(data, []byte(yamlDocSep)); i >= 0 {
+		sep := len(yamlDocSep)
+		i += sep
+		after := data[i:]
+		if len(after) == 0 {
+			if atEOF {
+				return len(data), data[:len(data)-sep], nil
+			}
+			return 0, nil, nil
+		}
+		if j := bytes.IndexByte(after, '\n'); j >= 0 {
+			return i + j + 1, data[0 : i-sep], nil
+		}
+		return 0, nil, nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
 }

--- a/pkg/openslosdk/encoding_test.go
+++ b/pkg/openslosdk/encoding_test.go
@@ -19,6 +19,7 @@ func TestDecode(t *testing.T) {
 	tests := map[string]struct {
 		testDataFile string
 		expected     []openslo.Object
+		skip         bool
 	}{
 		"single map": {
 			testDataFile: "decode/single_map.yaml",
@@ -149,6 +150,9 @@ func TestDecode(t *testing.T) {
 			testDataFile: "decode/v1_slos.yaml",
 		},
 		"v2alpha data source": {
+			// FIXME: Once we agree upon https://github.com/OpenSLO/OpenSLO/pull/290
+			// or otherwise go with the current state, this test should be enabled.
+			skip:         true,
 			testDataFile: "decode/v2alpha1_data_source.yaml",
 			expected: []openslo.Object{
 				v2alpha1.DataSource{
@@ -159,7 +163,7 @@ func TestDecode(t *testing.T) {
 					},
 					Spec: v2alpha1.DataSourceSpec{
 						Description: "CloudWatch Production Data Source",
-						DataSourceConnectionDetails: v2alpha1.DataSourceConnectionDetails{
+						DataSourceConnectionDetails: map[string]any{
 							"cloudWatch": map[string]any{
 								"accessKeyID":     "accessKey",
 								"secretAccessKey": "secretAccessKey",
@@ -170,6 +174,9 @@ func TestDecode(t *testing.T) {
 			},
 		},
 		"v2alpha slos": {
+			// FIXME: Once we agree upon https://github.com/OpenSLO/OpenSLO/pull/290
+			// or otherwise go with the current state, this test should be enabled.
+			skip: true,
 			expected: []openslo.Object{
 				v2alpha1.SLO{
 					APIVersion: openslo.VersionV2alpha1,
@@ -244,14 +251,17 @@ func TestDecode(t *testing.T) {
 			testDataFile: "decode/v2alpha1_slos.yaml",
 		},
 	}
-	for name, tt := range tests {
+	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			data := readTestData(t, testData, tt.testDataFile)
+			if tc.skip {
+				t.Skip("skipping test")
+			}
+			data := readTestData(t, testData, tc.testDataFile)
 			objects, err := Decode(bytes.NewReader(data), FormatYAML)
 
 			requireNoError(t, err)
-			requireLen(t, len(tt.expected), objects)
-			requireEqual(t, tt.expected, objects)
+			requireLen(t, len(tc.expected), objects)
+			requireEqual(t, tc.expected, objects)
 		})
 	}
 }
@@ -275,14 +285,14 @@ func requireNoError(t *testing.T, err error) {
 func requireLen[T any](t *testing.T, expected int, s []T) {
 	t.Helper()
 	if len(s) != expected {
-		t.Fatalf("expected %d objects, got %d", expected, len(s))
+		t.Fatalf("expected: %d objects, got: %d", expected, len(s))
 	}
 }
 
 func requireEqual(t *testing.T, expected, got any) {
 	t.Helper()
 	if !reflect.DeepEqual(expected, got) {
-		t.Fatalf("expected %v, got %v", expected, got)
+		t.Fatalf("expected:\n%v\ngot:\n%v", expected, got)
 	}
 }
 

--- a/pkg/openslosdk/format.go
+++ b/pkg/openslosdk/format.go
@@ -6,13 +6,16 @@ import "fmt"
 type ObjectFormat int
 
 const (
-	FormatYAML ObjectFormat = iota
+	FormatYAML ObjectFormat = iota + 1
+	FormatJSON
 )
 
 func (f ObjectFormat) String() string {
 	switch f {
 	case FormatYAML:
 		return "yaml"
+	case FormatJSON:
+		return "json"
 	default:
 		return "unknown"
 	}
@@ -20,7 +23,7 @@ func (f ObjectFormat) String() string {
 
 func (f ObjectFormat) Validate() error {
 	switch f {
-	case FormatYAML:
+	case FormatYAML, FormatJSON:
 		return nil
 	default:
 		return fmt.Errorf("unsupported %[1]T: %[1]s", f)


### PR DESCRIPTION
## Motivation

Supporting both JSON and YAML format is a pain. The way `go-yaml/yaml` works is not compatible with `encoding/json`.
These libraries support different functionalities (inlining), vary in a way they handle values (null values) and most importantly require defining separate tags and custom encoding methods. Furthermore, these encoding interfaces have different shapes, the `go-yaml/yaml` in its latest v3 release operates on `yaml.Node` for `UnmarshalYAML` custom decoder while `encoding/json` equivalent uses raw bytes.

## Summary

We discussed (with @fourstepper) alternatives to make OpenSLO maintenance and development easier.

- Stick to the v3 release and just make it work, it's tedious though and I think this PR shows why: https://github.com/OpenSLO/OpenSLO/pull/289
- Downgrade to [v2](https://pkg.go.dev/gopkg.in/yaml.v2#section-readme), but that would be just cringe, no idea what other problems we might encounter since this is a very old release.
- Use https://github.com/goccy/go-yaml, this is the library we're using at Nobl9 and it works well, it shares tags with JSON and its native serde interfaces operate on bytes.
- Use what k8s uses :) --> https://github.com/kubernetes-sigs/yaml

Overall, we chose the last approach. The problems we have were already encountered by a third, large party and solved. No need to reinvent the wheel. Additionally, since we want to be compatible with k8s CRDs, we'd be using the library under the hood anyway.
There's a blog post written by the library authors which is worth while reading: https://web.archive.org/web/20190603050330/http://ghodss.com/2014/the-right-way-to-handle-yaml-in-golang/.