### PR TITLE
Make OpenSLO spec concrete

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,6 @@ spec:
     - contain lowercase alphanumeric characters or `-`
     - start with an alphanumeric character
     - end with an alphanumeric character
-  - implementations are additionally encouraged to support names that:
-    - are up to 255 characters in length
-    - contain lowercase alphanumeric characters or `-`, `.`, `|`, `/`, `\`
 - **metadata.labels:** *map[string]string|string[]* - optional field `key` <> `value`
   - the `key` segment is required and must contain at most 63 characters beginning and ending
      with an alphanumeric character `[a-z0-9A-Z]` with dashes `-`, underscores `_`, dots `.`


### PR DESCRIPTION
# Problem statement

We claim that OpenSLO should be vendor agnostic, this means that spec should be running for different vendors without any additional changes. At least to the core, vendor specific annotations should be fine. With this bullet point there is possibility that the same spec won't work for two vendors although both of them clam that they support OpenSLO and they are right. 

Another thing is that recently we decided that we want to make OpenSLO not only easy to use but also easy to implement as we want new projects to start using this spec. Taking specification concrete and simple is step into this direction. 