### PR TITLE
feat: Better distinct composite objectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,8 @@ Either `target` or `targetPercent` must be used.
 ##### Notes (Composite SLO)
 
 **Composite SLO** goal of composite SLO is to enable user an end-to-end journey, it is done by defining many
-independent objectives. Each objective can have different queries, data sources and targets. The basic implementation
+independent objectives with indicator defined on the objective level.
+Each objective can have different queries, data sources and targets. The basic implementation
 assumes that the Composite Error Budget burns if the Error Budget for any of the SLO objectives within the Composite SLO
 is burning. The logic of those calculations is the same for Composite SLOs as for regular (standard) objectives and SLOs.
 

--- a/enhancements/v2alpha1.md
+++ b/enhancements/v2alpha1.md
@@ -47,6 +47,7 @@ spec:
       isRolling: false # if omitted assumed `false` if `calendar:` is present
   budgetingMethod: Occurrences | Timeslices | RatioTimeslices
   objectives: # see objectives below for details
+  compositeObjectives: # see composite objectives below for details
   alertPolicies: # see alert policies below for details
 ```
 
@@ -59,6 +60,24 @@ the tolerance levels for your metrics.
 
 ```yaml
 objectives:
+  - displayName: string # optional
+    labels: object # optional
+    op: lte | gte | lt | gt # conditional operator used to compare the SLI against the value. Only needed when using a thresholdMetric
+    value: numeric # optional, value used to compare threshold metrics. Only needed when using a thresholdMetric
+    target: numeric [0.0, 1.0) # budget target for given objective of the SLO, can't be used with targetPercent
+    targetPercent: numeric [0.0, 100) # budget target for given objective of the SLO, can't be used with target
+    timeSliceTarget: numeric (0.0, 1.0] # required only when budgetingMethod is set to TimeSlices
+    timeSliceWindow: number | duration-shorthand # required only when budgetingMethod is set to TimeSlices or RatioTimeslices
+```
+
+### Composite objectives
+
+**Note:** While in previous versions an SLO was deemed composite if there were at least two objectives,
+each having either `indicator` or `indicatorRef` defined.
+With `v2alpha1` we'll better distinct both types of SLO by either having `objectives` or `compositeObjectives` defined.
+
+```yaml
+compositeObjectives:
   - displayName: string # optional
     labels: object # optional
     op: lte | gte | lt | gt # conditional operator used to compare the SLI against the value. Only needed when using a thresholdMetric


### PR DESCRIPTION
## The problem

Currently we're being a bit vague when it comes to defining what constitutes a composite SLO.
I propose that in the future versions we're being more explicit about it.

## Solution

There are many different ways to go about it, maybe other ones I haven't thought about, feel free to suggest them :)

1. Add `type` field to SLO `spec`.
2. Add `type` field to each SLO `spec.objectives`.
3. Add new field `spec.compositeObjectives` which will be mutually exclusive with `spec.objectives`. _(proposed)_
