### PR TITLE
feat: Rename v2alpha1 to v2alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 - [Examples](examples/README.md)
 - [Glossary](glossary/README.md)
 - Work in progress for future versions
-  - [v2alpha1](enhancements/v2alpha1.md)
+  - [v2alpha](enhancements/v2alpha.md)
 - [SDK](#sdk)
 
 ## Introduction
@@ -151,7 +151,7 @@ prescriptive stance on this issue.
 
 A DataSource represents connection details with a particular metric source.
 
-> [Check work in progress for v2.](enhancements/v2alpha1.md#datasource)
+> [Check work in progress for v2.](enhancements/v2alpha.md#datasource)
 
 ```yaml
 apiVersion: openslo/v1
@@ -198,7 +198,7 @@ spec:
 A service level objective (SLO) is a target value or a range of values for
 a service level that is described by a service level indicator (SLI).
 
-> [Check work in progress for v2.](enhancements/v2alpha1.md#slo)
+> [Check work in progress for v2.](enhancements/v2alpha.md#slo)
 
 ```yaml
 apiVersion: openslo/v1
@@ -350,7 +350,7 @@ impact:
 
 A service level indicator (SLI) represents how to read metrics from data sources.
 
-> [Check work in progress for v2.](enhancements/v2alpha1.md#sli)
+> [Check work in progress for v2.](enhancements/v2alpha.md#sli)
 
 ```yaml
 apiVersion: openslo/v1

--- a/enhancements/v2alpha.md
+++ b/enhancements/v2alpha.md
@@ -1,4 +1,4 @@
-# v2alpha1
+# v2alpha
 
 This is the place for refining ideas for new versions of OpenSLO spec. It's not supposed to be stable, this is a living document
 
@@ -23,7 +23,7 @@ in the specification to reach that goal.
 it tells which kind of object should be referred there. This change should also apply to each objective.
 
 ```yaml
-apiVersion: openslo.com/v2alpha1
+apiVersion: openslo.com/v2alpha
 kind: SLO
 metadata:
   name: string
@@ -55,7 +55,7 @@ spec:
 Objectives are the thresholds for your SLOs. You can use objectives to define
 the tolerance levels for your metrics.
 
-**Note:** While in the previous version only one objective was allowed for Threshold metrics, with `v2alpha1` we'll allow any number of objectives.
+**Note:** While in the previous version only one objective was allowed for Threshold metrics, with `v2alpha` we'll allow any number of objectives.
 
 ```yaml
 objectives:
@@ -77,7 +77,7 @@ objectives:
 **Rationale:** Get rid of `metricSource` (reduce the level of indentation), and use the new syntax of `DataSource` directly.
 
 ```yaml
-apiVersion: openslo.com/v2alpha1
+apiVersion: openslo.com/v2alpha
 kind: SLI
 metadata:
   name: string
@@ -144,7 +144,7 @@ spec:
 An example of an SLO where SLI is inlined:
 
 ```yaml
-apiVersion: openslo.com/v2alpha1
+apiVersion: openslo.com/v2alpha
 kind: SLO
 metadata:
   name: foo-slo

--- a/pkg/openslo/v2alpha/alert_condition.go
+++ b/pkg/openslo/v2alpha/alert_condition.go
@@ -1,4 +1,4 @@
-package v2alpha1
+package v2alpha
 
 import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 

--- a/pkg/openslo/v2alpha/alert_notification_target.go
+++ b/pkg/openslo/v2alpha/alert_notification_target.go
@@ -1,4 +1,4 @@
-package v2alpha1
+package v2alpha
 
 import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 

--- a/pkg/openslo/v2alpha/alert_policy.go
+++ b/pkg/openslo/v2alpha/alert_policy.go
@@ -1,4 +1,4 @@
-package v2alpha1
+package v2alpha
 
 import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 

--- a/pkg/openslo/v2alpha/data_source.go
+++ b/pkg/openslo/v2alpha/data_source.go
@@ -1,4 +1,4 @@
-package v2alpha1
+package v2alpha
 
 import (
 	"encoding/json"

--- a/pkg/openslo/v2alpha/doc.go
+++ b/pkg/openslo/v2alpha/doc.go
@@ -1,4 +1,4 @@
-// Package v2alpha1 contains the OpenSLO specification version v2alpha1 definitions.
+// Package v2alpha contains the OpenSLO specification version v2alpha definitions.
 // It is a prototype of the next version of the OpenSLO specification.
 // It is not stable and is subject to breaking changes.
-package v2alpha1
+package v2alpha

--- a/pkg/openslo/v2alpha/objects.go
+++ b/pkg/openslo/v2alpha/objects.go
@@ -1,4 +1,4 @@
-package v2alpha1
+package v2alpha
 
 import (
 	"slices"
@@ -6,7 +6,7 @@ import (
 	"github.com/OpenSLO/OpenSLO/pkg/openslo"
 )
 
-const APIVersion = openslo.VersionV2alpha1
+const APIVersion = openslo.VersionV2alpha
 
 var supportedKinds = []openslo.Kind{
 	openslo.KindSLO,

--- a/pkg/openslo/v2alpha/service.go
+++ b/pkg/openslo/v2alpha/service.go
@@ -1,4 +1,4 @@
-package v2alpha1
+package v2alpha
 
 import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 

--- a/pkg/openslo/v2alpha/sli.go
+++ b/pkg/openslo/v2alpha/sli.go
@@ -1,4 +1,4 @@
-package v2alpha1
+package v2alpha
 
 import (
 	"github.com/OpenSLO/OpenSLO/pkg/openslo"

--- a/pkg/openslo/v2alpha/slo.go
+++ b/pkg/openslo/v2alpha/slo.go
@@ -1,4 +1,4 @@
-package v2alpha1
+package v2alpha
 
 import "github.com/OpenSLO/OpenSLO/pkg/openslo"
 

--- a/pkg/openslo/version.go
+++ b/pkg/openslo/version.go
@@ -6,9 +6,9 @@ import "fmt"
 type Version string
 
 const (
-	VersionV1alpha  Version = "openslo/v1alpha"
-	VersionV1       Version = "openslo/v1"
-	VersionV2alpha1 Version = "openslo.com/v2alpha1"
+	VersionV1alpha Version = "openslo/v1alpha"
+	VersionV1      Version = "openslo/v1"
+	VersionV2alpha Version = "openslo.com/v2alpha"
 )
 
 func (v Version) String() string {
@@ -19,7 +19,7 @@ func (v Version) Validate() error {
 	switch v {
 	case VersionV1alpha,
 		VersionV1,
-		VersionV2alpha1:
+		VersionV2alpha:
 		return nil
 	default:
 		return fmt.Errorf("unsupported %[1]T: %[1]s", v)

--- a/pkg/openslosdk/encoding.go
+++ b/pkg/openslosdk/encoding.go
@@ -14,7 +14,7 @@ import (
 	"github.com/OpenSLO/OpenSLO/pkg/openslo"
 	v1 "github.com/OpenSLO/OpenSLO/pkg/openslo/v1"
 	"github.com/OpenSLO/OpenSLO/pkg/openslo/v1alpha"
-	"github.com/OpenSLO/OpenSLO/pkg/openslo/v2alpha1"
+	"github.com/OpenSLO/OpenSLO/pkg/openslo/v2alpha"
 )
 
 func Decode(r io.Reader, format ObjectFormat) ([]openslo.Object, error) {
@@ -145,7 +145,7 @@ func decodeGenericObjects(genericObjects []genericObject) ([]openslo.Object, err
 			decodeFunc = decodeV1alphaObject
 		case openslo.VersionV1:
 			decodeFunc = decodeV1Object
-		case openslo.VersionV2alpha1:
+		case openslo.VersionV2alpha:
 			decodeFunc = decodeV2alphaObject
 		default:
 			return nil, fmt.Errorf("unsupported %[1]T: %[1]s", obj.apiVersion)
@@ -194,19 +194,19 @@ func decodeV1Object(generic genericObject) (openslo.Object, error) {
 func decodeV2alphaObject(generic genericObject) (openslo.Object, error) {
 	switch generic.kind {
 	case openslo.KindService:
-		return decodeJSONObject[v2alpha1.Service](generic.data)
+		return decodeJSONObject[v2alpha.Service](generic.data)
 	case openslo.KindSLO:
-		return decodeJSONObject[v2alpha1.SLO](generic.data)
+		return decodeJSONObject[v2alpha.SLO](generic.data)
 	case openslo.KindSLI:
-		return decodeJSONObject[v2alpha1.SLI](generic.data)
+		return decodeJSONObject[v2alpha.SLI](generic.data)
 	case openslo.KindDataSource:
-		return decodeJSONObject[v2alpha1.DataSource](generic.data)
+		return decodeJSONObject[v2alpha.DataSource](generic.data)
 	case openslo.KindAlertPolicy:
-		return decodeJSONObject[v2alpha1.AlertPolicy](generic.data)
+		return decodeJSONObject[v2alpha.AlertPolicy](generic.data)
 	case openslo.KindAlertCondition:
-		return decodeJSONObject[v2alpha1.AlertCondition](generic.data)
+		return decodeJSONObject[v2alpha.AlertCondition](generic.data)
 	case openslo.KindAlertNotificationTarget:
-		return decodeJSONObject[v2alpha1.AlertNotificationTarget](generic.data)
+		return decodeJSONObject[v2alpha.AlertNotificationTarget](generic.data)
 	default:
 		return nil, fmt.Errorf("unsupported %[1]T: %[1]s for version: %[2]s", generic.kind, generic.apiVersion)
 	}

--- a/pkg/openslosdk/encoding_test.go
+++ b/pkg/openslosdk/encoding_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/OpenSLO/OpenSLO/internal/assert"
 	"github.com/OpenSLO/OpenSLO/pkg/openslo"
 	v1 "github.com/OpenSLO/OpenSLO/pkg/openslo/v1"
-	"github.com/OpenSLO/OpenSLO/pkg/openslo/v2alpha1"
+	"github.com/OpenSLO/OpenSLO/pkg/openslo/v2alpha"
 )
 
 //go:embed test_data
@@ -200,15 +200,15 @@ func TestDecode(t *testing.T) {
 			testDataFile: "decode/v1_slos.yaml",
 		},
 		"v2alpha data source": {
-			testDataFile: "decode/v2alpha1_data_source.yaml",
+			testDataFile: "decode/v2alpha_data_source.yaml",
 			expected: []openslo.Object{
-				v2alpha1.DataSource{
-					APIVersion: openslo.VersionV2alpha1,
+				v2alpha.DataSource{
+					APIVersion: openslo.VersionV2alpha,
 					Kind:       openslo.KindDataSource,
-					Metadata: v2alpha1.Metadata{
+					Metadata: v2alpha.Metadata{
 						Name: "cloudWatch-prod",
 					},
-					Spec: v2alpha1.DataSourceSpec{
+					Spec: v2alpha.DataSourceSpec{
 						Description: "CloudWatch Production Data Source",
 						Type:        "cloudWatch",
 						ConnectionDetails: json.RawMessage(
@@ -220,28 +220,28 @@ func TestDecode(t *testing.T) {
 		},
 		"v2alpha slos": {
 			expected: []openslo.Object{
-				v2alpha1.SLO{
-					APIVersion: openslo.VersionV2alpha1,
+				v2alpha.SLO{
+					APIVersion: openslo.VersionV2alpha,
 					Kind:       openslo.KindSLO,
-					Metadata: v2alpha1.Metadata{
+					Metadata: v2alpha.Metadata{
 						Name: "foo-slo",
 					},
-					Spec: v2alpha1.SLOSpec{
+					Spec: v2alpha.SLOSpec{
 						Service: "foo",
-						SLI: &v2alpha1.SLOEmbeddedSLI{
-							Metadata: v2alpha1.Metadata{
+						SLI: &v2alpha.SLOEmbeddedSLI{
+							Metadata: v2alpha.Metadata{
 								Name: "foo-error",
 							},
-							Spec: v2alpha1.SLISpec{
-								RatioMetric: &v2alpha1.SLIRatioMetric{
+							Spec: v2alpha.SLISpec{
+								RatioMetric: &v2alpha.SLIRatioMetric{
 									Counter: true,
-									Good: &v2alpha1.SLIMetricSpec{
+									Good: &v2alpha.SLIMetricSpec{
 										DataSourceRef: "datadog-datasource",
 										Spec: map[string]any{
 											"query": "sum:trace.http.request.hits.by_http_status{http.status_code:200}.as_count()",
 										},
 									},
-									Total: &v2alpha1.SLIMetricSpec{
+									Total: &v2alpha.SLIMetricSpec{
 										DataSourceRef: "datadog-datasource",
 										Spec: map[string]any{
 											"query": "sum:trace.http.request.hits.by_http_status{*}.as_count()",
@@ -250,7 +250,7 @@ func TestDecode(t *testing.T) {
 								},
 							},
 						},
-						Objectives: []v2alpha1.Objective{
+						Objectives: []v2alpha.Objective{
 							{
 								DisplayName: "Foo Total Errors",
 								Target:      ptr(0.98),
@@ -258,27 +258,27 @@ func TestDecode(t *testing.T) {
 						},
 					},
 				},
-				v2alpha1.SLO{
-					APIVersion: openslo.VersionV2alpha1,
+				v2alpha.SLO{
+					APIVersion: openslo.VersionV2alpha,
 					Kind:       openslo.KindSLO,
-					Metadata: v2alpha1.Metadata{
+					Metadata: v2alpha.Metadata{
 						Name: "bar-slo",
 					},
-					Spec: v2alpha1.SLOSpec{
+					Spec: v2alpha.SLOSpec{
 						Service: "bar",
-						SLI: &v2alpha1.SLOEmbeddedSLI{
-							Metadata: v2alpha1.Metadata{
+						SLI: &v2alpha.SLOEmbeddedSLI{
+							Metadata: v2alpha.Metadata{
 								Name: "bar-error",
 							},
-							Spec: v2alpha1.SLISpec{
-								ThresholdMetric: &v2alpha1.SLIMetricSpec{
+							Spec: v2alpha.SLISpec{
+								ThresholdMetric: &v2alpha.SLIMetricSpec{
 									Spec: map[string]any{
 										"region":       "eu-central-1",
 										"clusterId":    "metrics-cluster",
 										"databaseName": "metrics-db",
 										"query":        "SELECT value, timestamp FROM metrics WHERE timestamp BETWEEN :date_from AND :date_to",
 									},
-									DataSourceSpec: &v2alpha1.DataSourceSpec{
+									DataSourceSpec: &v2alpha.DataSourceSpec{
 										Description: "Metrics Database",
 										Type:        "redshift",
 										ConnectionDetails: json.RawMessage(
@@ -291,7 +291,7 @@ func TestDecode(t *testing.T) {
 					},
 				},
 			},
-			testDataFile: "decode/v2alpha1_slos.yaml",
+			testDataFile: "decode/v2alpha_slos.yaml",
 		},
 	}
 	for name, tc := range tests {

--- a/pkg/openslosdk/test_data/decode/v2alpha_data_source.yaml
+++ b/pkg/openslosdk/test_data/decode/v2alpha_data_source.yaml
@@ -1,4 +1,4 @@
-apiVersion: openslo.com/v2alpha1
+apiVersion: openslo.com/v2alpha
 kind: DataSource
 metadata:
   name: cloudWatch-prod

--- a/pkg/openslosdk/test_data/decode/v2alpha_slos.yaml
+++ b/pkg/openslosdk/test_data/decode/v2alpha_slos.yaml
@@ -1,4 +1,4 @@
-- apiVersion: openslo.com/v2alpha1
+- apiVersion: openslo.com/v2alpha
   kind: SLO
   metadata:
     name: foo-slo
@@ -21,7 +21,7 @@
     objectives:
       - displayName: Foo Total Errors
         target: 0.98
-- apiVersion: openslo.com/v2alpha1
+- apiVersion: openslo.com/v2alpha
   kind: SLO
   metadata:
     name: bar-slo


### PR DESCRIPTION
We've discussed this issue on our last community meeting, we feel confident that there's no need to overcomplicate the versioning with additional minor versions for pre-release versions.