### PR TITLE
feat: Add v1alpha SLO validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenSLO/OpenSLO
 go 1.22
 
 require (
-	github.com/nobl9/govy v0.10.0
+	github.com/nobl9/govy v0.11.0
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/OpenSLO/OpenSLO
 go 1.22
 
 require (
-	github.com/nobl9/govy v0.9.0
+	github.com/nobl9/govy v0.10.0
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/nobl9/govy v0.10.0 h1:BaGkJ03E6YJ0679TpSLHQEhlyk0WmqWR4+Btvg53H5o=
-github.com/nobl9/govy v0.10.0/go.mod h1:O+xSiKwZ6gs/orRvH5qLkfkgyT7CkuXprRIq3C5uNXQ=
+github.com/nobl9/govy v0.11.0 h1:8Z+tj/eEz9YcFetg53K/jb4FYKB1gk6AiDtUq6NOrEg=
+github.com/nobl9/govy v0.11.0/go.mod h1:O+xSiKwZ6gs/orRvH5qLkfkgyT7CkuXprRIq3C5uNXQ=
 golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
 golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/nobl9/govy v0.9.0 h1:ZJaA0/44N+fWRICxVYL2A/6xovNBCQ7CsUVO4K8gYVQ=
-github.com/nobl9/govy v0.9.0/go.mod h1:O+xSiKwZ6gs/orRvH5qLkfkgyT7CkuXprRIq3C5uNXQ=
+github.com/nobl9/govy v0.10.0 h1:BaGkJ03E6YJ0679TpSLHQEhlyk0WmqWR4+Btvg53H5o=
+github.com/nobl9/govy v0.10.0/go.mod h1:O+xSiKwZ6gs/orRvH5qLkfkgyT7CkuXprRIq3C5uNXQ=
 golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
 golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/mod v0.20.0 h1:utOm6MM3R3dnawAiJgn0y+xvuYRsm1RKM/4giyfDgV0=

--- a/pkg/openslo/v1/slo.go
+++ b/pkg/openslo/v1/slo.go
@@ -198,6 +198,16 @@ var sloIndicatorValidation = govy.New(
 	Cascade(govy.CascadeModeStop)
 
 var sloTimeWindowValidation = govy.New(
+	govy.For(govy.GetSelf[SLOTimeWindow]()).
+		Rules(govy.NewRule(func(s SLOTimeWindow) error {
+			if s.IsRolling && s.Calendar != nil {
+				return govy.NewRuleError("'calendar' cannot be set when 'isRolling' is true")
+			}
+			if !s.IsRolling && s.Calendar == nil {
+				return govy.NewRuleError("'calendar' must be set when 'isRolling' is false")
+			}
+			return nil
+		})),
 	govy.For(func(t SLOTimeWindow) DurationShorthand { return t.Duration }).
 		WithName("duration").
 		Required().

--- a/pkg/openslo/v1/slo_test.go
+++ b/pkg/openslo/v1/slo_test.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/nobl9/govy/pkg/govy"
@@ -54,6 +55,21 @@ func TestSLO_Validate_Metadata(t *testing.T) {
 }
 
 func TestSLO_Validate_Spec(t *testing.T) {
+	t.Run("description ok", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.Description = strings.Repeat("A", 1050)
+		err := slo.Validate()
+		govytest.AssertNoError(t, err)
+	})
+	t.Run("description too long", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.Description = strings.Repeat("A", 1051)
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.description",
+			Code:         rules.ErrorCodeStringMaxLength,
+		})
+	})
 	t.Run("invalid budgetingMethod", func(t *testing.T) {
 		slo := validSLO()
 		slo.Spec.BudgetingMethod = "invalid"
@@ -494,6 +510,20 @@ func runSLOIndicatorTests(t *testing.T, path string, sloGetter func(SLOIndicator
 	})
 }
 
+func TestSLO_IsComposite(t *testing.T) {
+	slo := validSLO()
+	assert.False(t, slo.IsComposite())
+
+	slo = validCompositeSLOWithSLIRef()
+	assert.True(t, slo.IsComposite())
+
+	t.Run("at least one objective is composite", func(t *testing.T) {
+		slo.Spec.Objectives = append(slo.Spec.Objectives, slo.Spec.Objectives[0])
+		slo.Spec.Objectives[0].SLOIndicator = nil
+		assert.True(t, slo.IsComposite())
+	})
+}
+
 func validSLO() SLO {
 	return NewSLO(
 		Metadata{
@@ -560,20 +590,6 @@ func validSLO() SLO {
 			},
 		},
 	)
-}
-
-func TestSLO_IsComposite(t *testing.T) {
-	slo := validSLO()
-	assert.False(t, slo.IsComposite())
-
-	slo = validCompositeSLOWithSLIRef()
-	assert.True(t, slo.IsComposite())
-
-	t.Run("at least one objective is composite", func(t *testing.T) {
-		slo.Spec.Objectives = append(slo.Spec.Objectives, slo.Spec.Objectives[0])
-		slo.Spec.Objectives[0].SLOIndicator = nil
-		assert.True(t, slo.IsComposite())
-	})
 }
 
 func validSLOWithInlinedAlertPolicy() SLO {

--- a/pkg/openslo/v1/slo_test.go
+++ b/pkg/openslo/v1/slo_test.go
@@ -150,6 +150,35 @@ func TestSLO_Validate_Spec_TimeWindows(t *testing.T) {
 			return slo
 		})
 	})
+	t.Run("calendar set when isRolling is true", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.TimeWindow[0] = SLOTimeWindow{
+			Duration:  NewDurationShorthand(1, DurationShorthandUnitWeek),
+			IsRolling: true,
+			Calendar: &SLOCalendar{
+				StartTime: "2022-01-01 12:00:00",
+				TimeZone:  "America/New_York",
+			},
+		}
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.timeWindow[0]",
+			Message:      "'calendar' cannot be set when 'isRolling' is true",
+		})
+	})
+	t.Run("calendar missing when isRolling is false", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.TimeWindow[0] = SLOTimeWindow{
+			Duration:  NewDurationShorthand(1, DurationShorthandUnitWeek),
+			IsRolling: false,
+			Calendar:  nil,
+		}
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.timeWindow[0]",
+			Message:      "'calendar' must be set when 'isRolling' is false",
+		})
+	})
 }
 
 func TestSLO_Validate_Spec_Objectives(t *testing.T) {

--- a/pkg/openslo/v1alpha/examples/slos.yml
+++ b/pkg/openslo/v1alpha/examples/slos.yml
@@ -1,0 +1,43 @@
+- apiVersion: openslo/v1alpha
+  kind: SLO
+  metadata:
+    name: web-availability
+    displayName: SLO for web availability
+    labels:
+      env:
+        - prod
+      team:
+        - team-a
+        - team-b
+  spec:
+    description: X% of search requests are successful
+    service: web
+    indicator:
+      metadata:
+        name: web-successful-requests-ratio
+      spec:
+        counter: true
+        ratioMetric:
+          good:
+            metricSource:
+              type: Prometheus
+              spec:
+                query: sum(http_requests{k8s_cluster="prod",component="web",code=~"2xx|4xx"})
+          total:
+            metricSource:
+              type: Prometheus
+              spec:
+                query: sum(http_requests{k8s_cluster="prod",component="web"})
+    timeWindow:
+      - duration: 1w
+        isRolling: false
+        calendar:
+          startTime: 2022-01-01 12:00:00
+          timeZone: America/New_York
+    budgetingMethod: Timeslices
+    objectives:
+      - displayName: Good
+        op: gt
+        target: 0.995
+        timeSliceTarget: 0.95
+        timeSliceWindow: 1m

--- a/pkg/openslo/v1alpha/slo.go
+++ b/pkg/openslo/v1alpha/slo.go
@@ -1,8 +1,24 @@
 package v1alpha
 
-import "github.com/OpenSLO/OpenSLO/pkg/openslo"
+import (
+	"time"
+
+	"github.com/OpenSLO/OpenSLO/internal"
+	"github.com/OpenSLO/OpenSLO/pkg/openslo"
+	"github.com/nobl9/govy/pkg/govy"
+	"github.com/nobl9/govy/pkg/rules"
+)
 
 var _ = openslo.Object(SLO{})
+
+func NewSLO(metadata Metadata, spec SLOSpec) SLO {
+	return SLO{
+		APIVersion: APIVersion,
+		Kind:       openslo.KindSLO,
+		Metadata:   metadata,
+		Spec:       spec,
+	}
+}
 
 type SLO struct {
 	APIVersion openslo.Version `json:"apiVersion"`
@@ -24,55 +40,210 @@ func (s SLO) GetName() string {
 }
 
 func (s SLO) Validate() error {
-	return nil
+	return sloValidation.Validate(s)
 }
 
 type SLOSpec struct {
-	TimeWindows     []TimeWindow `json:"timeWindows"`
-	BudgetingMethod string       `json:"budgetingMethod"`
-	Description     string       `json:"description,omitempty"`
-	Indicator       *Indicator   `json:"indicator"`
-	Service         string       `json:"service"`
-	Objectives      []Objective  `json:"objectives"`
+	TimeWindows     []SLOTimeWindow    `json:"timeWindows"`
+	BudgetingMethod SLOBudgetingMethod `json:"budgetingMethod"`
+	Description     string             `json:"description,omitempty"`
+	Indicator       *SLOIndicator      `json:"indicator"`
+	Service         string             `json:"service"`
+	Objectives      []SLOObjective     `json:"objectives"`
 }
 
-type Indicator struct {
-	ThresholdMetric MetricSourceSpec `json:"thresholdMetric"`
+type SLOBudgetingMethod string
+
+const (
+	SLOBudgetingMethodOccurrences SLOBudgetingMethod = "Occurrences"
+	SLOBudgetingMethodTimeslices  SLOBudgetingMethod = "Timeslices"
+)
+
+var validSLOBudgetingMethods = []SLOBudgetingMethod{
+	SLOBudgetingMethodOccurrences,
+	SLOBudgetingMethodTimeslices,
 }
 
-type MetricSourceSpec struct {
+type SLOIndicator struct {
+	ThresholdMetric SLOMetricSourceSpec `json:"thresholdMetric"`
+}
+
+type SLOMetricSourceSpec struct {
 	Source    string `json:"source"`
 	QueryType string `json:"queryType"`
 	Query     string `json:"query"`
 }
 
-type Objective struct {
-	ObjectiveBase   `json:",inline"`
-	RatioMetrics    *RatioMetrics `json:"ratioMetrics"`
-	BudgetTarget    *float64      `json:"target"`
-	TimeSliceTarget *float64      `json:"timeSliceTarget,omitempty"`
-	Operator        *string       `json:"op,omitempty"`
+type SLOObjective struct {
+	DisplayName     string           `json:"displayName"`
+	Value           float64          `json:"value"`
+	RatioMetrics    *SLORatioMetrics `json:"ratioMetrics"`
+	BudgetTarget    *float64         `json:"target"`
+	TimeSliceTarget *float64         `json:"timeSliceTarget,omitempty"`
+	Operator        Operator         `json:"op,omitempty"`
 }
 
-type RatioMetrics struct {
-	Good    MetricSourceSpec `json:"good"`
-	Total   MetricSourceSpec `json:"total"`
-	Counter bool             `json:"counter"`
+type SLORatioMetrics struct {
+	Good    SLOMetricSourceSpec `json:"good"`
+	Total   SLOMetricSourceSpec `json:"total"`
+	Counter bool                `json:"counter"`
 }
 
-type ObjectiveBase struct {
-	DisplayName string  `json:"displayName"`
-	Value       float64 `json:"value"`
+type SLOTimeWindow struct {
+	Unit      SLOTimeWindowUnit `json:"unit"`
+	Count     int               `json:"count"`
+	IsRolling bool              `json:"isRolling"`
+	Calendar  *SLOCalendar      `json:"calendar,omitempty"`
 }
 
-type TimeWindow struct {
-	Unit      string    `json:"unit"`
-	Count     int       `json:"count"`
-	IsRolling bool      `json:"isRolling"`
-	Calendar  *Calendar `json:"calendar,omitempty"`
+type SLOTimeWindowUnit string
+
+const (
+	SLOTimeWindowUnitSecond  SLOTimeWindowUnit = "Second"
+	SLOTimeWindowUnitDay     SLOTimeWindowUnit = "Day"
+	SLOTimeWindowUnitWeek    SLOTimeWindowUnit = "Week"
+	SLOTimeWindowUnitMonth   SLOTimeWindowUnit = "Month"
+	SLOTimeWindowUnitQuarter SLOTimeWindowUnit = "Quarter"
+)
+
+var validSLOTimeWindowUnits = []SLOTimeWindowUnit{
+	SLOTimeWindowUnitSecond,
+	SLOTimeWindowUnitDay,
+	SLOTimeWindowUnitWeek,
+	SLOTimeWindowUnitMonth,
+	SLOTimeWindowUnitQuarter,
 }
 
-type Calendar struct {
+type SLOCalendar struct {
 	StartTime string `json:"startTime"`
 	TimeZone  string `json:"timeZone"`
 }
+
+type Operator string
+
+const (
+	OperatorGT  Operator = "gt"
+	OperatorLT  Operator = "lt"
+	OperatorGTE Operator = "gte"
+	OperatorLTE Operator = "lte"
+)
+
+var validOperators = []Operator{
+	OperatorGT,
+	OperatorLT,
+	OperatorGTE,
+	OperatorLTE,
+}
+
+var sloValidation = govy.New(
+	validationRulesAPIVersion(func(s SLO) openslo.Version { return s.APIVersion }),
+	validationRulesKind(func(s SLO) openslo.Kind { return s.Kind }, openslo.KindSLO),
+	validationRulesMetadata(func(s SLO) Metadata { return s.Metadata }),
+	govy.For(func(s SLO) SLOSpec { return s.Spec }).
+		WithName("spec").
+		Include(sloSpecValidation),
+).WithNameFunc(internal.ObjectNameFunc[SLO])
+
+var sloSpecValidation = govy.New(
+	govy.For(func(spec SLOSpec) string { return spec.Description }).
+		WithName("description").
+		Rules(rules.StringMaxLength(1050)),
+	govy.For(func(spec SLOSpec) string { return spec.Service }).
+		WithName("service").
+		Required(),
+	govy.ForPointer(func(spec SLOSpec) *SLOIndicator { return spec.Indicator }).
+		WithName("indicator").
+		Include(sloIndicatorValidation),
+	govy.For(func(spec SLOSpec) SLOBudgetingMethod { return spec.BudgetingMethod }).
+		WithName("budgetingMethod").
+		Required().
+		Rules(rules.OneOf(validSLOBudgetingMethods...)),
+	govy.ForSlice(func(spec SLOSpec) []SLOTimeWindow { return spec.TimeWindows }).
+		WithName("timeWindow").
+		Rules(rules.SliceLength[[]SLOTimeWindow](1, 1)).
+		IncludeForEach(sloTimeWindowValidation),
+	govy.ForSlice(func(spec SLOSpec) []SLOObjective { return spec.Objectives }).
+		WithName("objectives").
+		IncludeForEach(sloObjectiveValidation),
+)
+
+var sloIndicatorValidation = govy.New(
+	govy.For(func(i SLOIndicator) SLOMetricSourceSpec { return i.ThresholdMetric }).
+		WithName("thresholdMetric").
+		Required().
+		Include(sloMetricSourceSpecValidation),
+)
+
+var sloTimeWindowValidation = govy.New(
+	govy.For(govy.GetSelf[SLOTimeWindow]()).
+		Rules(govy.NewRule(func(s SLOTimeWindow) error {
+			if s.IsRolling && s.Calendar != nil {
+				return govy.NewRuleError("'calendar' cannot be set when 'isRolling' is true")
+			}
+			if !s.IsRolling && s.Calendar == nil {
+				return govy.NewRuleError("'calendar' must be set when 'isRolling' is false")
+			}
+			return nil
+		})),
+	govy.For(func(t SLOTimeWindow) SLOTimeWindowUnit { return t.Unit }).
+		WithName("unit").
+		Required().
+		Rules(rules.OneOf(validSLOTimeWindowUnits...)),
+	govy.For(func(t SLOTimeWindow) int { return t.Count }).
+		WithName("count").
+		Rules(rules.GT(0)),
+	govy.ForPointer(func(t SLOTimeWindow) *SLOCalendar { return t.Calendar }).
+		WithName("calendar").
+		Include(govy.New(
+			govy.For(func(c SLOCalendar) string { return c.StartTime }).
+				WithName("startTime").
+				Rules(rules.StringDateTime(time.DateTime)),
+			govy.For(func(c SLOCalendar) string { return c.TimeZone }).
+				WithName("timeZone").
+				Rules(rules.StringTimeZone()),
+		)),
+)
+
+var sloObjectiveValidation = govy.New(
+	govy.For(func(s SLOObjective) string { return s.DisplayName }).
+		WithName("displayName").
+		Rules(rules.StringMaxLength(1050)),
+	govy.ForPointer(func(s SLOObjective) *SLORatioMetrics { return s.RatioMetrics }).
+		WithName("ratioMetrics").
+		Include(sloRatioMetricsValidation),
+	govy.ForPointer(func(s SLOObjective) *float64 { return s.BudgetTarget }).
+		WithName("target").
+		Required().
+		Rules(rules.GTE(0.0), rules.LT(1.0)),
+	govy.For(func(s SLOObjective) Operator { return s.Operator }).
+		WithName("op").
+		When(
+			func(s SLOObjective) bool { return s.RatioMetrics == nil },
+			govy.WhenDescription("only required when 'thresholdMetric' is set"),
+		).
+		Rules(rules.OneOf(validOperators...)),
+)
+
+var sloRatioMetricsValidation = govy.New(
+	govy.For(func(s SLORatioMetrics) SLOMetricSourceSpec { return s.Good }).
+		WithName("good").
+		Include(sloMetricSourceSpecValidation),
+	govy.For(func(s SLORatioMetrics) SLOMetricSourceSpec { return s.Total }).
+		WithName("total").
+		Include(sloMetricSourceSpecValidation),
+)
+
+var sloMetricSourceSpecValidation = govy.New(
+	govy.For(func(s SLOMetricSourceSpec) string { return s.Source }).
+		WithName("source").
+		Required().
+		Rules(rules.StringAlpha()),
+	govy.For(func(s SLOMetricSourceSpec) string { return s.QueryType }).
+		WithName("queryType").
+		Required().
+		Rules(rules.StringAlpha()),
+	govy.For(func(s SLOMetricSourceSpec) string { return s.Query }).
+		WithName("query").
+		Required().
+		Rules(rules.StringNotEmpty()),
+)

--- a/pkg/openslo/v1alpha/slo_example_test.go
+++ b/pkg/openslo/v1alpha/slo_example_test.go
@@ -32,8 +32,9 @@ func ExampleSLO() {
       - displayName: Good
         target: 0.995
         timeSliceTarget: 0.95
+        value: 1
         ratioMetrics:
-          counter: true
+          incremental: true
           good:
             source: datadog
             queryType: query
@@ -69,6 +70,7 @@ func ExampleSLO() {
 					DisplayName:     "Good",
 					BudgetTarget:    ptr(0.995),
 					TimeSliceTarget: ptr(0.95),
+					Value:           ptr(1.0),
 					RatioMetrics: &v1alpha.SLORatioMetrics{
 						Incremental: true,
 						Good: v1alpha.SLOMetricSourceSpec{
@@ -117,18 +119,18 @@ func ExampleSLO() {
 	//     objectives:
 	//     - displayName: Good
 	//       ratioMetrics:
-	//         counter: true
 	//         good:
 	//           query: sum:requests{service:web,status:2xx}
 	//           queryType: query
 	//           source: datadog
+	//         incremental: true
 	//         total:
 	//           query: sum:requests{service:web}
 	//           queryType: query
 	//           source: datadog
 	//       target: 0.995
 	//       timeSliceTarget: 0.95
-	//       value: 0
+	//       value: 1
 	//     service: web
 	//     timeWindows:
 	//     - calendar:

--- a/pkg/openslo/v1alpha/slo_example_test.go
+++ b/pkg/openslo/v1alpha/slo_example_test.go
@@ -70,7 +70,7 @@ func ExampleSLO() {
 					BudgetTarget:    ptr(0.995),
 					TimeSliceTarget: ptr(0.95),
 					RatioMetrics: &v1alpha.SLORatioMetrics{
-						Counter: true,
+						Incremental: true,
 						Good: v1alpha.SLOMetricSourceSpec{
 							Source:    "datadog",
 							QueryType: "query",

--- a/pkg/openslo/v1alpha/slo_example_test.go
+++ b/pkg/openslo/v1alpha/slo_example_test.go
@@ -1,0 +1,126 @@
+package v1alpha_test
+
+import (
+	"bytes"
+	"os"
+	"reflect"
+
+	"github.com/OpenSLO/OpenSLO/pkg/openslo/v1alpha"
+	"github.com/OpenSLO/OpenSLO/pkg/openslosdk"
+)
+
+func ExampleSLO() {
+	// Raw SLO object in YAML format.
+	const sloYAML = `
+- apiVersion: openslo/v1
+  kind: SLO
+  metadata:
+    name: web-availability
+    displayName: SLO for web availability
+  spec:
+    description: X% of search requests are successful
+    service: web
+    indicator:
+      metadata:
+        name: web-successful-requests-ratio
+      spec:
+        ratioMetric:
+          counter: true
+          good:
+            metricSource:
+              type: Prometheus
+              spec:
+                query: sum(http_requests{k8s_cluster="prod",component="web",code=~"2xx|4xx"})
+          total:
+            metricSource:
+              type: Prometheus
+              spec:
+                query: sum(http_requests{k8s_cluster="prod",component="web"})
+    timeWindow:
+      - duration: 1w
+        isRolling: false
+        calendar:
+          startTime: 2022-01-01 12:00:00
+          timeZone: America/New_York
+    budgetingMethod: Timeslices
+    objectives:
+      - displayName: Good
+        op: gt
+        target: 0.995
+        timeSliceTarget: 0.95
+        timeSliceWindow: 1m
+`
+	// Define SLO programmatically.
+	slo := v1alpha.NewSLO(
+		v1alpha.Metadata{
+			Name:        "web-availability",
+			DisplayName: "SLO for web availability",
+		},
+		v1alpha.SLOSpec{
+			Description:     "X% of search requests are successful",
+			Service:         "web",
+			BudgetingMethod: v1alpha.SLOBudgetingMethodTimeslices,
+			Objectives: []v1alpha.SLOObjective{
+				{
+					DisplayName: "Good",
+				},
+			},
+		},
+	)
+	// Read the raw SLO object.
+	objects, err := openslosdk.Decode(bytes.NewBufferString(sloYAML), openslosdk.FormatYAML)
+	if err != nil {
+		panic(err)
+	}
+	// Compare the raw SLO object with the programmatically defined SLO object.
+	if !reflect.DeepEqual(objects[0], slo) {
+		panic("SLO objects are not equal!")
+	}
+	// Validate the SLO object.
+	if err = slo.Validate(); err != nil {
+		panic(err)
+	}
+	// Encode the SLO object to YAML and write it to stdout.
+	if err = openslosdk.Encode(os.Stdout, openslosdk.FormatYAML, slo); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// - apiVersion: openslo/v1
+	//   kind: SLO
+	//   metadata:
+	//     displayName: SLO for web availability
+	//     name: web-availability
+	//   spec:
+	//     budgetingMethod: Timeslices
+	//     description: X% of search requests are successful
+	//     indicator:
+	//       metadata:
+	//         name: web-successful-requests-ratio
+	//       spec:
+	//         ratioMetric:
+	//           counter: true
+	//           good:
+	//             metricSource:
+	//               spec:
+	//                 query: sum(http_requests{k8s_cluster="prod",component="web",code=~"2xx|4xx"})
+	//               type: Prometheus
+	//           total:
+	//             metricSource:
+	//               spec:
+	//                 query: sum(http_requests{k8s_cluster="prod",component="web"})
+	//               type: Prometheus
+	//     objectives:
+	//     - displayName: Good
+	//       op: gt
+	//       target: 0.995
+	//       timeSliceTarget: 0.95
+	//       timeSliceWindow: 1m
+	//     service: web
+	//     timeWindow:
+	//     - calendar:
+	//         startTime: "2022-01-01 12:00:00"
+	//         timeZone: America/New_York
+	//       duration: 1w
+	//       isRolling: false
+}

--- a/pkg/openslo/v1alpha/slo_test.go
+++ b/pkg/openslo/v1alpha/slo_test.go
@@ -1,0 +1,223 @@
+package v1alpha
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/nobl9/govy/pkg/govy"
+	"github.com/nobl9/govy/pkg/govytest"
+	"github.com/nobl9/govy/pkg/rules"
+
+	"github.com/OpenSLO/OpenSLO/internal/assert"
+	"github.com/OpenSLO/OpenSLO/pkg/openslo"
+)
+
+var sloValidationMessageRegexp = getValidationMessageRegexp(openslo.KindSLO)
+
+func TestSLO_Validate_Ok(t *testing.T) {
+	for _, slo := range []SLO{
+		validSLO(),
+	} {
+		err := slo.Validate()
+		govytest.AssertNoError(t, err)
+	}
+}
+
+func TestSLO_Validate_VersionAndKind(t *testing.T) {
+	slo := validSLO()
+	slo.APIVersion = "v0.1"
+	slo.Kind = openslo.KindService
+	err := slo.Validate()
+	assert.Require(t, assert.Error(t, err))
+	assert.True(t, sloValidationMessageRegexp.MatchString(err.Error()))
+	govytest.AssertError(t, err,
+		govytest.ExpectedRuleError{
+			PropertyName: "apiVersion",
+			Code:         rules.ErrorCodeEqualTo,
+		},
+		govytest.ExpectedRuleError{
+			PropertyName: "kind",
+			Code:         rules.ErrorCodeEqualTo,
+		},
+	)
+}
+
+func TestSLO_Validate_Metadata(t *testing.T) {
+	runMetadataTests(t, "metadata", func(m Metadata) SLO {
+		condition := validSLO()
+		condition.Metadata = m
+		return condition
+	})
+}
+
+func TestSLO_Validate_Spec(t *testing.T) {
+	t.Run("invalid budgetingMethod", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.BudgetingMethod = "invalid"
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.budgetingMethod",
+			Code:         rules.ErrorCodeOneOf,
+		})
+	})
+	for _, method := range validSLOBudgetingMethods {
+		t.Run(fmt.Sprintf("budgetingMethod %s", method), func(t *testing.T) {
+			slo := validSLO()
+			slo.Spec.BudgetingMethod = method
+			err := slo.Validate()
+			govytest.AssertNoError(t, err)
+		})
+	}
+	t.Run("missing service", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.Service = ""
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.service",
+			Code:         rules.ErrorCodeRequired,
+		})
+	})
+	t.Run("missing both indicator definition in spec and objectives", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.Indicator = nil
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec",
+			Message: "'indicator' or 'indicatorRef' fields must either be defined on the 'spec' level (standard SLOs)" +
+				" or on the 'spec.objectives[*]' level (composite SLOs), but not both",
+			Code: rules.ErrorCodeMutuallyExclusive,
+		})
+	})
+}
+
+func TestSLO_Validate_Spec_TimeWindows(t *testing.T) {
+	t.Run("missing timeWindow", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.TimeWindows = []SLOTimeWindow{}
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.timeWindow",
+			Code:         rules.ErrorCodeSliceLength,
+		})
+	})
+	t.Run("too many timeWindows", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.TimeWindows = []SLOTimeWindow{
+			slo.Spec.TimeWindows[0],
+			slo.Spec.TimeWindows[0],
+		}
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.timeWindow",
+			Code:         rules.ErrorCodeSliceLength,
+		})
+	})
+}
+
+func TestSLO_Validate_Spec_Objectives(t *testing.T) {
+	t.Run("target", func(t *testing.T) {
+		for _, tc := range []struct {
+			in        float64
+			errorCode govy.ErrorCode
+		}{
+			{0.0, ""},
+			{0.9999, ""},
+			{1.0, rules.ErrorCodeLessThan},
+			{-0.1, rules.ErrorCodeGreaterThanOrEqualTo},
+		} {
+			slo := validSLO()
+			slo.Spec.Objectives[0].BudgetTarget = ptr(tc.in)
+			err := slo.Validate()
+			if tc.errorCode != "" {
+				govytest.AssertError(t, err, govytest.ExpectedRuleError{
+					PropertyName: "spec.objectives[0].target",
+					Code:         tc.errorCode,
+				})
+			} else {
+				govytest.AssertNoError(t, err)
+			}
+		}
+	})
+	t.Run("budgetTarget is missing", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.Objectives[0].BudgetTarget = nil
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.objectives[0]",
+			Message:      "one of [target, targetPercent] properties must be set, none was provided",
+			Code:         rules.ErrorCodeMutuallyExclusive,
+		})
+	})
+	t.Run("empty operator", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.Objectives[0].Operator = ""
+		err := slo.Validate()
+		govytest.AssertNoError(t, err)
+	})
+	t.Run("valid operator values", func(t *testing.T) {
+		for _, op := range validOperators {
+			slo := validSLO()
+			slo.Spec.Objectives[0].Operator = op
+			err := slo.Validate()
+			govytest.AssertNoError(t, err)
+		}
+	})
+	t.Run("invalid operator value", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.Objectives[0].Operator = "less_than"
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.objectives[0].op",
+			Code:         rules.ErrorCodeOneOf,
+		})
+	})
+}
+
+func runSLOMetricSpecValidationTests(t *testing.T) {}
+
+func validSLO() SLO {
+	return NewSLO(
+		Metadata{
+			Name:        "web-availability",
+			DisplayName: "SLO for web availability",
+		},
+		SLOSpec{
+			Description: "X% of search requests are successful",
+			Service:     "web",
+			TimeWindows: []SLOTimeWindow{
+				{
+					Unit:      SLOTimeWindowUnitWeek,
+					Count:     1,
+					IsRolling: false,
+					Calendar: &SLOCalendar{
+						StartTime: "2022-01-01 12:00:00",
+						TimeZone:  "America/New_York",
+					},
+				},
+			},
+			BudgetingMethod: SLOBudgetingMethodTimeslices,
+			Objectives: []SLOObjective{
+				{
+					DisplayName:     "Good",
+					BudgetTarget:    ptr(0.995),
+					TimeSliceTarget: ptr(0.95),
+					RatioMetrics: &SLORatioMetrics{
+						Counter: true,
+						Good: SLOMetricSourceSpec{
+							Source:    "datadog",
+							QueryType: "query",
+							Query:     "sum:requests{service:web,status:2xx}",
+						},
+						Total: SLOMetricSourceSpec{
+							Source:    "datadog",
+							QueryType: "query",
+							Query:     "sum:requests{service:web}",
+						},
+					},
+				},
+			},
+		},
+	)
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/pkg/openslo/v1alpha/slo_test.go
+++ b/pkg/openslo/v1alpha/slo_test.go
@@ -191,6 +191,15 @@ func TestSLO_Validate_Spec_Objectives(t *testing.T) {
 			Code:         rules.ErrorCodeRequired,
 		})
 	})
+	t.Run("value is missing", func(t *testing.T) {
+		slo := validSLO()
+		slo.Spec.Objectives[0].Value = nil
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.objectives[0].value",
+			Code:         rules.ErrorCodeRequired,
+		})
+	})
 	t.Run("ratioMetrics - operator set", func(t *testing.T) {
 		slo := validSLO()
 		slo.Spec.Objectives[0].Operator = OperatorGT
@@ -225,6 +234,23 @@ func TestSLO_Validate_Spec_Objectives(t *testing.T) {
 			PropertyName: "spec.objectives[0].op",
 			Code:         rules.ErrorCodeOneOf,
 		})
+	})
+	t.Run("budgeting method timeslices - missing timeSliceTarget", func(t *testing.T) {
+		slo := validThresholdSLO()
+		slo.Spec.BudgetingMethod = SLOBudgetingMethodTimeslices
+		slo.Spec.Objectives[0].TimeSliceTarget = nil
+		err := slo.Validate()
+		govytest.AssertError(t, err, govytest.ExpectedRuleError{
+			PropertyName: "spec.objectives[0].timeSliceTarget",
+			Code:         rules.ErrorCodeRequired,
+		})
+	})
+	t.Run("budgeting method occurences - missing timeSliceTarget", func(t *testing.T) {
+		slo := validThresholdSLO()
+		slo.Spec.BudgetingMethod = SLOBudgetingMethodOccurrences
+		slo.Spec.Objectives[0].TimeSliceTarget = nil
+		err := slo.Validate()
+		govytest.AssertNoError(t, err)
 	})
 }
 
@@ -283,8 +309,9 @@ func validSLO() SLO {
 					DisplayName:     "Good",
 					BudgetTarget:    ptr(0.995),
 					TimeSliceTarget: ptr(0.95),
+					Value:           ptr(1.0),
 					RatioMetrics: &SLORatioMetrics{
-						Counter: true,
+						Incremental: true,
 						Good: SLOMetricSourceSpec{
 							Source:    "datadog",
 							QueryType: "query",
@@ -335,6 +362,7 @@ func validThresholdSLO() SLO {
 					DisplayName:     "Good",
 					BudgetTarget:    ptr(0.995),
 					TimeSliceTarget: ptr(0.95),
+					Value:           ptr(1.0),
 				},
 			},
 		},

--- a/pkg/openslo/v1alpha/slo_test.go
+++ b/pkg/openslo/v1alpha/slo_test.go
@@ -245,7 +245,7 @@ func TestSLO_Validate_Spec_Objectives(t *testing.T) {
 			Code:         rules.ErrorCodeRequired,
 		})
 	})
-	t.Run("budgeting method occurences - missing timeSliceTarget", func(t *testing.T) {
+	t.Run("budgeting method occurrences - missing timeSliceTarget", func(t *testing.T) {
 		slo := validThresholdSLO()
 		slo.Spec.BudgetingMethod = SLOBudgetingMethodOccurrences
 		slo.Spec.Objectives[0].TimeSliceTarget = nil


### PR DESCRIPTION
V1alpha version rules have been based both on [oslo implementation](https://github.com/OpenSLO/oslo/blob/main/pkg/manifest/v1alpha/objects.go) and [this README.md state](https://github.com/OpenSLO/OpenSLO/blob/9faf14edaaf9d7fee2c06e326b2655a9d594e251/README.md#objectives).
When the two contradicted each other I chose the README version overt `oslo`.